### PR TITLE
fix: 调整放弃并结算的点击后等待时间，避免过快导致界面未更新而无法识别下一步按钮#108

### DIFF
--- a/tasks/currency_wars/RerollStart.py
+++ b/tasks/currency_wars/RerollStart.py
@@ -488,10 +488,10 @@ class RerollStart(Executable):
                 logger.error("未识别到放弃并结算入口")
                 result = False
                 return self._reset_cw_flags_after_abort(result) if reset_flags else result
-            self.operator.click_box(withdraw_and_settle, after_sleep=2.5)
+            self.operator.click_box(withdraw_and_settle, after_sleep=1.8)
 
             # 下一步
-            next_step = self.operator.wait_img(CWIMG.NEXT_STEP, timeout=8, interval=0.5)
+            next_step = self.operator.wait_img(CWIMG.NEXT_STEP, timeout=16, interval=0.5)
             if next_step is None:
                 logger.error("点击放弃并结算后，未识别到下一步")
                 result = False


### PR DESCRIPTION
我真没招了，我直接把等待时间从2.5+8，增加到1.8+16，他要还是有概率触发识别不到下一步，我真得给欧姆弥赛亚磕几个，再用七种方式点二十一柱圣香了