### PR TITLE
fix:修复公告窗口&更新窗口的Markdown渲染字体颜色问题

### DIFF
--- a/SRAFrontend/Controls/AnnouncementBoardView.axaml
+++ b/SRAFrontend/Controls/AnnouncementBoardView.axaml
@@ -4,23 +4,10 @@
              xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:models="clr-namespace:SRAFrontend.Models"
              xmlns:mdxaml="https://github.com/whistyun/Markdown.Avalonia.Tight"
-             xmlns:ctb="clr-namespace:ColorTextBlock.Avalonia;assembly=ColorTextBlock.Avalonia"
              x:Class="SRAFrontend.Controls.AnnouncementBoardView"
              x:DataType="local:AnnouncementBoardViewModel"
              Width="600"
              Height="400">
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.ThemeDictionaries>
-                <ResourceDictionary x:Key="Light">
-                    <SolidColorBrush x:Key="AnnouncementForegroundBrush" Color="Black" />
-                </ResourceDictionary>
-                <ResourceDictionary x:Key="Dark">
-                    <SolidColorBrush x:Key="AnnouncementForegroundBrush" Color="White" />
-                </ResourceDictionary>
-            </ResourceDictionary.ThemeDictionaries>
-        </ResourceDictionary>
-    </UserControl.Resources>
     <Design.DataContext>
         <local:AnnouncementBoardViewModel />
     </Design.DataContext>
@@ -34,24 +21,7 @@
             </TabControl.ItemTemplate>
             <TabControl.ContentTemplate>
                 <DataTemplate DataType="{x:Type models:Announcement}">
-                    <mdxaml:MarkdownScrollViewer Markdown="{Binding Content}">
-                        <mdxaml:MarkdownScrollViewer.Styles>
-                            <!-- 普通文本 -->
-                            <Style Selector="TextBlock">
-                                <Setter Property="Foreground" Value="{DynamicResource AnnouncementForegroundBrush}"/>
-                            </Style>
-                            <!-- Markdown 标题类（来自 Markdown.Avalonia.Tight） -->
-                            <Style Selector="TextBlock.Heading1, TextBlock.Heading2, TextBlock.Heading3, TextBlock.Heading4, TextBlock.Heading5, TextBlock.Heading6">
-                                <Setter Property="Foreground" Value="{DynamicResource AnnouncementForegroundBrush}"/>
-                            </Style>
-                            <Style Selector="ctb|CTextBlock.Heading1, ctb|CTextBlock.Heading2, ctb|CTextBlock.Heading3, ctb|CTextBlock.Heading4, ctb|CTextBlock.Heading5, ctb|CTextBlock.Heading6">
-                                <Setter Property="Foreground" Value="{DynamicResource AnnouncementForegroundBrush}"/>
-                            </Style>
-                            <Style Selector="Run">
-                                <Setter Property="Foreground" Value="{DynamicResource AnnouncementForegroundBrush}"/>
-                            </Style>
-                        </mdxaml:MarkdownScrollViewer.Styles>
-                    </mdxaml:MarkdownScrollViewer>
+                    <local:ThemedMarkdownScrollViewer Markdown="{Binding Content}" />
                 </DataTemplate>
             </TabControl.ContentTemplate>
         </TabControl>

--- a/SRAFrontend/Controls/ThemedMarkdownScrollViewer.cs
+++ b/SRAFrontend/Controls/ThemedMarkdownScrollViewer.cs
@@ -1,0 +1,66 @@
+using Avalonia;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+using ColorTextBlock.Avalonia;
+using Markdown.Avalonia;
+
+namespace SRAFrontend.Controls;
+
+/// <summary>
+/// 修复了暗色主题下标题颜色问题的 MarkdownScrollViewer
+/// 解决 Markdown.Avalonia.Tight 库标题硬编码为黑色的问题
+/// </summary>
+public class ThemedMarkdownScrollViewer : MarkdownScrollViewer
+{
+    public ThemedMarkdownScrollViewer()
+    {
+        LayoutUpdated += OnLayoutUpdated;
+    }
+
+    private void OnLayoutUpdated(object? sender, System.EventArgs e)
+    {
+        ForceHeadingColor(this);
+    }
+
+    private void ForceHeadingColor(Visual? visual)
+    {
+        if (visual == null) return;
+
+        // 只处理 Heading 类的 CTextBlock
+        if (visual is CTextBlock ctb &&
+            (ctb.Classes.Contains("Heading1") ||
+             ctb.Classes.Contains("Heading2") ||
+             ctb.Classes.Contains("Heading3") ||
+             ctb.Classes.Contains("Heading4") ||
+             ctb.Classes.Contains("Heading5") ||
+             ctb.Classes.Contains("Heading6")))
+        {
+            // 根据当前主题动态设置颜色
+            var targetColor = GetThemeForegroundColor();
+            if (!Equals(ctb.Foreground, targetColor))
+            {
+                ctb.Foreground = targetColor;
+            }
+        }
+
+        foreach (var child in visual.GetVisualChildren())
+        {
+            ForceHeadingColor(child);
+        }
+    }
+
+    /// <summary>
+    /// 根据当前主题获取合适的前景色
+    /// </summary>
+    private IBrush GetThemeForegroundColor()
+    {
+        var app = Application.Current;
+        if (app == null) return Brushes.White;
+
+        var themeVariant = app.ActualThemeVariant;
+        
+        // 根据主题返回相应的颜色
+        return themeVariant == ThemeVariant.Dark ? Brushes.White : Brushes.Black;
+    }
+}

--- a/SRAFrontend/ViewModels/CommonModel.cs
+++ b/SRAFrontend/ViewModels/CommonModel.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
-using Markdown.Avalonia;
 using Microsoft.Extensions.Logging;
 using SRAFrontend.Controls;
 using SRAFrontend.Data;
@@ -115,15 +114,17 @@ public class CommonModel(
             var manualUpgradeButton =
                 SukiMessageBoxButtonsFactory.CreateButton("手动更新", SukiMessageBoxResult.OK, "Flat Accent");
             var cancelButton = SukiMessageBoxButtonsFactory.CreateButton("忽略", SukiMessageBoxResult.Cancel);
+            var markdownViewer = new ThemedMarkdownScrollViewer
+            {
+                Markdown = response.Data.ReleaseNote,
+                Width = 600,
+                Height = 400
+            };
+            
             var result = await SukiMessageBox.ShowDialog(new SukiMessageBoxHost
             {
                 Header = "Update Available - " + response.Data.VersionName,
-                Content = new MarkdownScrollViewer
-                {
-                    Markdown = response.Data.ReleaseNote,
-                    Width = 600,
-                    Height = 400
-                },
+                Content = markdownViewer,
                 ActionButtonsSource = [autoUpgradeButton, manualUpgradeButton, cancelButton]
             });
             switch (result)


### PR DESCRIPTION
问题： CTextBlock: Foreground=#99000000, Classes=Heading3会覆盖文字颜色，原因未知
解决方法：添加新控件，并在控件加载时重新修改字体颜色

新增文件：
  - SRAFrontend/Controls/ThemedMarkdownScrollViewer.cs
 
修改文件：
  - SRAFrontend/Controls/AnnouncementBoardView.axaml
  - SRAFrontend/ViewModels/CommonModel.cs

以上。

> [!WARNING]
> 此方案在Linux开发环境通过测试，Windows效果理论相同。
> **如果怀疑其在Windows上的效果，请先尝试进行测试再继续。**