### PR TITLE
fix(test): 修复冒烟测试在 CI 环境下的编码崩溃

### DIFF
--- a/tests/backend/test_smoke.py
+++ b/tests/backend/test_smoke.py
@@ -6,10 +6,15 @@
 避免单元测试的 conftest.py 中的 sys.modules mock 污染。
 """
 
+import os
 import subprocess
 import sys
 
 import pytest
+
+# CI 环境（Windows runner）默认编码为 cp1252，无法输出中文字符。
+# 强制所有子进程使用 UTF-8 编码，避免 UnicodeEncodeError。
+_UTF8_ENV = {**os.environ, "PYTHONUTF8": "1"}
 
 
 class TestCLISmoke:
@@ -19,18 +24,20 @@ class TestCLISmoke:
         """main.py --help 能正常输出"""
         result = subprocess.run(
             [sys.executable, "main.py", "--help"],
-            capture_output=True, text=True, timeout=10
+            capture_output=True, encoding="utf-8", errors="replace",
+            timeout=10, env=_UTF8_ENV
         )
-        assert result.returncode == 0
+        assert result.returncode == 0, f"--help 失败:\n{result.stderr}"
         assert "SRA-cli" in result.stdout or "usage" in result.stdout.lower()
 
     def test_main_version(self):
         """main.py --version 能正常输出版本号"""
         result = subprocess.run(
             [sys.executable, "main.py", "--version"],
-            capture_output=True, text=True, timeout=10
+            capture_output=True, encoding="utf-8", errors="replace",
+            timeout=10, env=_UTF8_ENV
         )
-        assert result.returncode == 0
+        assert result.returncode == 0, f"--version 失败:\n{result.stderr}"
 
 
 class TestTaskRegistrySmoke:
@@ -41,7 +48,8 @@ class TestTaskRegistrySmoke:
         """在独立子进程中执行验证代码，避免 conftest mock 污染"""
         return subprocess.run(
             [sys.executable, "-c", code],
-            capture_output=True, text=True, timeout=10
+            capture_output=True, encoding="utf-8", errors="replace",
+            timeout=10, env=_UTF8_ENV
         )
 
     def test_config_toml_loads(self):


### PR DESCRIPTION
## 背景

  #151 合并后，上游重构了 `main.py`，在 `parse_args()` 之前新增了 `load_settings()` 调用并设置了中文本地化。这导致 argparse 的 help 文本包含中文字符，在 GitHub Actions Windows runner（默认编码 cp1252）上触发 `UnicodeEncodeError` 崩溃。

  ## 原因

  CI 环境的调用链：
  1. `main.py --help` → `load_settings()` → 找不到 `settings.json`（日志报错，不致命）
  2. `Resource.set_language(0)` → help 文本设为中文
  3. argparse `print_help()` → 写 stdout → cp1252 无法编码中文字符 `：`（U+FF1A）→ 崩溃

  本地不复现，因为本地编码为 GBK/UTF-8，都能处理中文。

  ## 修复

  - `subprocess.run` 统一使用 `encoding="utf-8", errors="replace"` 替代 `text=True`，确保父进程解码不报错
  - 注入 `PYTHONUTF8=1` 环境变量，确保子进程写 stdout 时也使用 UTF-8
  - 补充 assert 失败时输出 stderr，便于 CI 上快速定位问题

  ## 测试结果

  pytest tests/backend/ -v
  33 passed in 1.97s