### PR TITLE
标题：feat: 用 TaskOrder 替换 EnabledTasks，支持任务自定义顺序（前后端同步）

### DIFF
--- a/SRACore/config.toml
+++ b/SRACore/config.toml
@@ -2,6 +2,7 @@
 name = "启动游戏"
 main = "StartGameTask"
 module = "tasks.StartGameTask"
+fixed = "first"
 
 [[tasks]]
 name = "清开拓力"
@@ -22,3 +23,4 @@ module = "tasks.CosmicStrifeTask"
 name = "任务完成"
 main = "MissionAccomplishTask"
 module = "tasks.MissionAccomplishTask"
+fixed = "last"

--- a/SRACore/thread/task_process.py
+++ b/SRACore/thread/task_process.py
@@ -1,8 +1,9 @@
 # type: ignore
 import importlib
+from dataclasses import dataclass
+from typing import Any
 
 import tomllib
-from typing import Any
 
 from SRACore.localization import Resource
 from SRACore.operators import Operator
@@ -16,19 +17,24 @@ from SRACore.util.data_persister import load_cache, load_config
 from SRACore.util.logger import logger, setup_logger
 
 
+@dataclass
+class TaskMeta:
+    """任务元信息：存储任务类和固定位置约束"""
+    task_class: type
+    fixed: str | None = None  # "first" / "last" / None
+
+
 class TaskManager:
     """
-    任务管理器线程，负责按顺序执行多个任务（如启动游戏、体力刷取等）。
+    任务管理器，负责按顺序执行多个任务（如启动游戏、体力刷取等）。
     支持通过配置动态加载任务列表，并处理任务的中断和错误。
     """
 
     def __init__(self):
-        """
-        初始化任务管理器。
-        """
+        """初始化任务管理器，从 config.toml 加载任务注册表。"""
         self.log_level = "TRACE"
         self.log_queue = None
-        self.task_list: list[type] = []
+        self.task_registry: dict[str, TaskMeta] = {}
         with open("SRACore/config.toml", "rb") as f:
             tasks = tomllib.load(f).get("tasks", [])
             for task in tasks:
@@ -40,8 +46,12 @@ class TaskManager:
                     raise TypeError(f"Task class {main_class} does not inherit from BaseTask")
                 if not callable(getattr(_class, "run", None)):
                     raise TypeError(f"Task class {main_class} does not implement a callable 'run' method")
-                self.task_list.append(_class)
-        logger.debug(f"Successfully load task: {self.task_list}")
+                self.task_registry[main_class] = TaskMeta(
+                    task_class=_class,
+                    fixed=task.get("fixed"),
+                )
+        # 向后兼容：保留 task_list 供旧代码使用
+        logger.debug(f"Successfully load task: {list(self.task_registry.keys())}")
 
     def run(self, *args: Any) -> None:
         """
@@ -97,53 +107,57 @@ class TaskManager:
         """
         根据配置名称加载配置，并返回需要执行的任务实例列表。
 
-        Args:
-            config_name (str): 配置名称
-
-        Returns:
-            List[Executable]: 可执行任务实例列表（已过滤未选中的任务）
-
-        Raises:
-            Exception: 如果配置加载或任务实例化失败（异常会被上层捕获）
+        fixed="first" 的任务固定在最前，fixed="last" 的任务固定在最后。
+        配置版本不符（Version < StaticVersion）时由前端丢弃，后端不做迁移。
         """
         # 加载指定配置
         config = load_config(config_name)
         if config is None:
             return []
         print_config = config.copy()
-        print_config["StartGamePassword"] = "******"
+        if "StartGamePassword" in print_config:
+            print_config["StartGamePassword"] = "******"
         logger.debug('config: ' + str(print_config))
-        # 从配置中读取任务选择列表（如 [True, False, True]）
-        task_select = config.get("EnabledTasks")
-        logger.debug('task_select: ' + str(task_select))
-        if not task_select:
+
+        task_order = config.get("TaskOrder")
+        if not task_order:
             return []
-        tasks = []
 
-        # 遍历 task_select，根据选择状态实例化对应任务
-        for index, is_select in enumerate(task_select):
-            # 检查：1. 任务被选中 2. 索引在 task_list 范围内
-            if is_select and index < len(self.task_list):
-                try:
-                    # 实例化任务类
-                    tasks.append(self.task_list[index](Operator(), config))
-                except Exception as e:
-                    logger.exception(Resource.task_instantiateFailed(index, str(e)))
-        return tasks
+        logger.debug('task_order: ' + str(task_order))
 
-    def run_task(self, task: int | str, config_name: str | None = None) -> bool:
+        # 按 fixed 分组
+        first_tasks = []
+        ordered_tasks = []
+        last_tasks = []
+
+        for name in task_order:
+            meta = self.task_registry.get(name)
+            if meta is None:
+                logger.warning(f"未知任务: {name}，跳过")
+                continue
+            if meta.fixed == "first":
+                first_tasks.append(meta.task_class)
+            elif meta.fixed == "last":
+                last_tasks.append(meta.task_class)
+            else:
+                ordered_tasks.append(meta.task_class)
+
+        # 拼接：固定头 + 用户排序 + 固定尾
+        final_order = first_tasks + ordered_tasks + last_tasks
+
+        operator = Operator()
+        return [cls(operator, config) for cls in final_order]
+
+    def run_task(self, task: str, config_name: str | None = None) -> bool:
         """
-        根据配置名称和任务索引或名称执行单个任务。
+        根据配置名称和任务名称执行单个任务。
 
         Args:
-            task (int | str): 任务索引（int）或任务类名称（str）
-            config_name (str): 配置名称
+            task (str): 任务类名称（如 "StartGameTask"）
+            config_name (str | None): 配置名称，为 None 时从缓存读取当前配置
 
         Returns:
             bool: 任务执行结果（成功返回 True，失败返回 False）
-
-        Raises:
-            ValueError: 如果任务未找到或配置加载失败
         """
         setup_logger(level=self.log_level, queue=self.log_queue)
         logger.debug('[Start]')
@@ -180,27 +194,27 @@ class TaskManager:
 
         Args:
             config_name (str): 配置名称
-            task ( str): 任务索引或任务类名称（str）
+            task (str): 任务类名称（如 "StartGameTask"）
 
         Returns:
-            BaseTask: 任务实例
-
-        Raises:
-            ValueError: 如果任务未找到或配置加载失败
+            BaseTask | None: 任务实例，未找到或配置加载失败时返回 None
         """
-        # 根据参数类型获取任务类
+        # 从 task_registry 查找任务类
         task_class = None
-        if task.isdecimal():
-            index = int(task)
-            if 0 <= index < len(self.task_list):
-                task_class = self.task_list[index]
+        meta = self.task_registry.get(task)
+        if meta:
+            task_class = meta.task_class
         else:
-            for cls in self.task_list:
-                if cls.__name__.lower() == task.lower():
-                    task_class = cls
+            # 不区分大小写回退查找
+            for name, m in self.task_registry.items():
+                if name.lower() == task.lower():
+                    task_class = m.task_class
                     break
             else:
-                task_class = importlib.import_module(f"tasks.{task}").__getattribute__(task)
+                try:
+                    task_class = importlib.import_module(f"tasks.{task}").__getattribute__(task)
+                except (ModuleNotFoundError, AttributeError):
+                    return None
         if task_class is None:
             return None
         try:
@@ -209,8 +223,9 @@ class TaskManager:
             if config is None:
                 return None
             print_config = config.copy()
-            print_config["StartGamePassword"] = "******"
-            logger.debug('config: ' + str(config))
+            if "StartGamePassword" in print_config:
+                print_config["StartGamePassword"] = "******"
+            logger.debug('config: ' + str(print_config))
             # 实例化任务类
             return task_class(Operator(), config)
         except Exception as e:

--- a/SRAFrontend/Models/Config.cs
+++ b/SRAFrontend/Models/Config.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Avalonia.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -13,7 +14,13 @@ public partial class Config : ObservableObject
     [ObservableProperty] private bool _afterLogout; // 任务完成后是否登出
     [ObservableProperty] private bool _afterShutdown; // 任务完成后关机
     [ObservableProperty] private bool _afterSleep; // 任务完成后睡眠
-    [ObservableProperty] private bool[] _enabledTasks = [true, false, false, false, false]; // 各任务启用状态
+
+    /// <summary>
+    ///     任务执行顺序：出现在列表中 = 启用，顺序 = 执行顺序。
+    ///     使用类名（如 "StartGameTask"）标识任务，不依赖索引。
+    ///     默认为空列表，由 DataPersister.LoadConfig 在迁移旧配置或新建配置时填充。
+    /// </summary>
+    [ObservableProperty] private List<string> _taskOrder = [];
 
     [ObservableProperty] private string _name = "Default"; // 配置名称，默认为 "Default"
     [ObservableProperty] private string _receiveRewardRedeemCodes = ""; // 兑换码列表
@@ -35,7 +42,7 @@ public partial class Config : ObservableObject
     [ObservableProperty] private int _currencyWarsRunTimes = 1; // 货币战争运行次数
     [ObservableProperty] private string _currencyWarsUsername = ""; // 货币战争用户名
     [ObservableProperty] private int _currencyWarsDifficulty; // 货币战争难度：0=最低难度，1=最高难度，2=当前难度（不切换难度）
-    
+
     // 货币战争 - 刷开局 ps: CwRs = Currency wars Reroll start
     [ObservableProperty] private string _cwRsInvestEnvironments = ""; // 刷开局 - 期望投资环境，空格分隔
     [ObservableProperty] private string _cwRsInvestStrategies = ""; // 刷开局 - 期望投资策略，空格分隔
@@ -55,7 +62,7 @@ public partial class Config : ObservableObject
 
     [ObservableProperty] [property: JsonIgnore]
     private string _startGameUsername = ""; // 游戏启动用户名
-    
+
     [ObservableProperty] private bool _trailblazePowerReplenishEnable; // 是否补充体力
     [ObservableProperty] private int _trailblazePowerReplenishTimes; // 补充体力次数
     [ObservableProperty] private int _trailblazePowerReplenishWay; // 补充体力方式
@@ -69,5 +76,31 @@ public partial class Config : ObservableObject
     [JsonPropertyName("StartGameUsername")] public string EncryptedStartGameUsername { get; set; } = "";
 
     public int Version { get; init; } = StaticVersion; // 配置版本号
-    public static int StaticVersion => 3;
+    public static int StaticVersion => 4;
+
+    /// <summary>
+    ///     检查指定任务是否在 TaskOrder 中（即是否启用）。
+    ///     供 XAML CheckBox 绑定使用。
+    /// </summary>
+    public bool IsTaskEnabled(string taskName)
+    {
+        return TaskOrder.Contains(taskName);
+    }
+
+    /// <summary>
+    ///     切换指定任务的启用状态：启用则加入 TaskOrder 末尾，禁用则移除。
+    ///     供 XAML CheckBox 绑定使用。
+    /// </summary>
+    public void SetTaskEnabled(string taskName, bool enabled)
+    {
+        if (enabled && !TaskOrder.Contains(taskName))
+        {
+            TaskOrder.Add(taskName);
+        }
+        else if (!enabled)
+        {
+            TaskOrder.Remove(taskName);
+        }
+        OnPropertyChanged(nameof(TaskOrder));
+    }
 }

--- a/SRAFrontend/Models/TaskOrderItem.cs
+++ b/SRAFrontend/Models/TaskOrderItem.cs
@@ -1,0 +1,24 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SRAFrontend.Models;
+
+/// <summary>
+///     排序面板中的任务项，绑定到排序 UI。
+/// </summary>
+public partial class TaskOrderItem : ObservableObject
+{
+    /// <summary>任务类名（如 "StartGameTask"），用于与 TaskOrder 同步</summary>
+    public string TaskClassName { get; init; } = "";
+
+    /// <summary>显示名称（本地化后的，如 "启动游戏"）</summary>
+    public string DisplayName { get; init; } = "";
+
+    /// <summary>是否为固定位置任务（fixed=first/last），固定任务不可移动</summary>
+    public bool IsFixed { get; init; }
+
+    /// <summary>是否可向左移动（排序面板绑定）</summary>
+    [ObservableProperty] private bool _canMoveLeft;
+
+    /// <summary>是否可向右移动（排序面板绑定）</summary>
+    [ObservableProperty] private bool _canMoveRight;
+}

--- a/SRAFrontend/Utils/DataPersister.cs
+++ b/SRAFrontend/Utils/DataPersister.cs
@@ -95,7 +95,12 @@ public static class DataPersister
         var json = File.ReadAllText(configPath);
         if (string.IsNullOrWhiteSpace(json)) return new Config { Name = name };
         var config = JsonSerializer.Deserialize<Config>(json);
-        return config == null || config.Version < Config.StaticVersion ? new Config { Name = name } : config;
+        if (config == null) return new Config { Name = name };
+
+        // 版本过旧的配置直接丢弃重建
+        if (config.Version < Config.StaticVersion) return new Config { Name = name };
+
+        return config;
     }
 
     public static void SaveConfig(Config config)

--- a/SRAFrontend/ViewModels/TaskPageViewModel.cs
+++ b/SRAFrontend/ViewModels/TaskPageViewModel.cs
@@ -59,6 +59,13 @@ public partial class TaskPageViewModel : PageViewModel
             if (args.PropertyName != nameof(Cache.CurrentConfigIndex)) return;
             _configService.SwitchConfig(_cacheService.Cache.ConfigNames[_cacheService.Cache.CurrentConfigIndex]);
             CurrentConfig = _configService.Config!;
+            // 刷新任务启用状态绑定
+            OnPropertyChanged(nameof(IsStartGameEnabled));
+            OnPropertyChanged(nameof(IsTrailblazePowerEnabled));
+            OnPropertyChanged(nameof(IsReceiveRewardsEnabled));
+            OnPropertyChanged(nameof(IsCosmicStrifeEnabled));
+            OnPropertyChanged(nameof(IsMissionAccomplishEnabled));
+            RefreshTaskOrderItems();
         }
 
         _cacheService.Cache.PropertyChanged += OnCachePropertyChanged;
@@ -67,9 +74,161 @@ public partial class TaskPageViewModel : PageViewModel
         {
             RefreshStrategies();
         }
+
+        RefreshTaskOrderItems();
     }
 
     public ControlPanelViewModel ControlPanelViewModel { get; }
+
+    // ============================================================
+    // 任务启用状态计算属性（供 XAML CheckBox 绑定）
+    // ============================================================
+
+    public bool IsStartGameEnabled
+    {
+        get => CurrentConfig.IsTaskEnabled("StartGameTask");
+        set { CurrentConfig.SetTaskEnabled("StartGameTask", value); OnPropertyChanged(); RefreshTaskOrderItems(); }
+    }
+
+    public bool IsTrailblazePowerEnabled
+    {
+        get => CurrentConfig.IsTaskEnabled("TrailblazePowerTask");
+        set { CurrentConfig.SetTaskEnabled("TrailblazePowerTask", value); OnPropertyChanged(); RefreshTaskOrderItems(); }
+    }
+
+    public bool IsReceiveRewardsEnabled
+    {
+        get => CurrentConfig.IsTaskEnabled("ReceiveRewardsTask");
+        set { CurrentConfig.SetTaskEnabled("ReceiveRewardsTask", value); OnPropertyChanged(); RefreshTaskOrderItems(); }
+    }
+
+    public bool IsCosmicStrifeEnabled
+    {
+        get => CurrentConfig.IsTaskEnabled("CosmicStrifeTask");
+        set { CurrentConfig.SetTaskEnabled("CosmicStrifeTask", value); OnPropertyChanged(); RefreshTaskOrderItems(); }
+    }
+
+    public bool IsMissionAccomplishEnabled
+    {
+        get => CurrentConfig.IsTaskEnabled("MissionAccomplishTask");
+        set { CurrentConfig.SetTaskEnabled("MissionAccomplishTask", value); OnPropertyChanged(); RefreshTaskOrderItems(); }
+    }
+
+    // ============================================================
+    // 任务排序面板
+    // ============================================================
+
+    /// <summary>固定位置任务集合</summary>
+    private static readonly HashSet<string> FixedTasks = new() { "StartGameTask", "MissionAccomplishTask" };
+
+    // 各非 fixed 任务的可移动状态（供 XAML 绑定）
+    [ObservableProperty] private bool _isTrailblazePowerCanMoveLeft;
+    [ObservableProperty] private bool _isTrailblazePowerCanMoveRight;
+    [ObservableProperty] private bool _isReceiveRewardsCanMoveLeft;
+    [ObservableProperty] private bool _isReceiveRewardsCanMoveRight;
+    [ObservableProperty] private bool _isCosmicStrifeCanMoveLeft;
+    [ObservableProperty] private bool _isCosmicStrifeCanMoveRight;
+
+    /// <summary>按 TaskOrder 排列的 Tab 标题列表（供 TabControl 动态排序）</summary>
+    [ObservableProperty] private AvaloniaList<string> _orderedTabKeys = [];
+
+    /// <summary>根据 CurrentConfig.TaskOrder 刷新排序面板</summary>
+    private void RefreshTaskOrderItems()
+    {
+        var order = CurrentConfig.TaskOrder;
+
+        // 刷新 Tab 顺序：fixed 任务钉在首尾，非 fixed 任务按 TaskOrder 中的顺序排列，
+        // 未启用的非 fixed 任务追加在尾部（fixed last 任务之前）
+        var allTasks = new List<string> { "StartGameTask", "TrailblazePowerTask", "ReceiveRewardsTask", "CosmicStrifeTask", "MissionAccomplishTask" };
+        var newTabOrder = new List<string>();
+        // 先按 TaskOrder 中的非 fixed 任务顺序排，fixed 任务钉在首尾
+        var fixedFirst = allTasks.Where(t => t == "StartGameTask").ToList();
+        var fixedLast = allTasks.Where(t => t == "MissionAccomplishTask").ToList();
+        var orderedMiddle = order.Where(t => !FixedTasks.Contains(t) && allTasks.Contains(t)).ToList();
+        var unorderedMiddle = allTasks.Where(t => !FixedTasks.Contains(t) && !orderedMiddle.Contains(t)).ToList();
+        newTabOrder.AddRange(fixedFirst);
+        newTabOrder.AddRange(orderedMiddle);
+        newTabOrder.AddRange(unorderedMiddle);
+        newTabOrder.AddRange(fixedLast);
+        OrderedTabKeys = new AvaloniaList<string>(newTabOrder);
+
+        // 刷新可移动状态
+        for (var i = 0; i < order.Count; i++)
+        {
+            var name = order[i];
+            var isFixed = FixedTasks.Contains(name);
+            if (isFixed) continue;
+
+            // 向左找：跳过 fixed，看是否存在非 fixed 的邻居
+            var canLeft = false;
+            for (var j = i - 1; j >= 0; j--)
+            {
+                if (!FixedTasks.Contains(order[j])) { canLeft = true; break; }
+            }
+            // 向右找：跳过 fixed，看是否存在非 fixed 的邻居
+            var canRight = false;
+            for (var j = i + 1; j < order.Count; j++)
+            {
+                if (!FixedTasks.Contains(order[j])) { canRight = true; break; }
+            }
+
+            switch (name)
+            {
+                case "TrailblazePowerTask":
+                    IsTrailblazePowerCanMoveLeft = canLeft;
+                    IsTrailblazePowerCanMoveRight = canRight;
+                    break;
+                case "ReceiveRewardsTask":
+                    IsReceiveRewardsCanMoveLeft = canLeft;
+                    IsReceiveRewardsCanMoveRight = canRight;
+                    break;
+                case "CosmicStrifeTask":
+                    IsCosmicStrifeCanMoveLeft = canLeft;
+                    IsCosmicStrifeCanMoveRight = canRight;
+                    break;
+            }
+        }
+
+        if (!order.Contains("TrailblazePowerTask")) { IsTrailblazePowerCanMoveLeft = false; IsTrailblazePowerCanMoveRight = false; }
+        if (!order.Contains("ReceiveRewardsTask")) { IsReceiveRewardsCanMoveLeft = false; IsReceiveRewardsCanMoveRight = false; }
+        if (!order.Contains("CosmicStrifeTask")) { IsCosmicStrifeCanMoveLeft = false; IsCosmicStrifeCanMoveRight = false; }
+    }
+
+    [RelayCommand]
+    private void MoveTaskLeft(string taskClassName)
+    {
+        var order = CurrentConfig.TaskOrder;
+        var idx = order.IndexOf(taskClassName);
+        if (idx <= 0) return;
+
+        // 找左边第一个非 fixed 的位置交换
+        var targetIdx = idx - 1;
+        while (targetIdx >= 0 && FixedTasks.Contains(order[targetIdx]))
+            targetIdx--;
+        if (targetIdx < 0) return;
+
+        (order[idx], order[targetIdx]) = (order[targetIdx], order[idx]);
+        OnPropertyChanged(nameof(CurrentConfig));
+        RefreshTaskOrderItems();
+    }
+
+    [RelayCommand]
+    private void MoveTaskRight(string taskClassName)
+    {
+        var order = CurrentConfig.TaskOrder;
+        var idx = order.IndexOf(taskClassName);
+        if (idx < 0 || idx >= order.Count - 1) return;
+
+        // 找右边第一个非 fixed 的位置交换
+        var targetIdx = idx + 1;
+        while (targetIdx < order.Count && FixedTasks.Contains(order[targetIdx]))
+            targetIdx++;
+        if (targetIdx >= order.Count) return;
+
+        (order[idx], order[targetIdx]) = (order[targetIdx], order[idx]);
+        OnPropertyChanged(nameof(CurrentConfig));
+        RefreshTaskOrderItems();
+    }
 
     public AvaloniaList<TrailblazePowerTask> Tasks => [
             new(AddTaskItem)

--- a/SRAFrontend/Views/TaskPageView.axaml
+++ b/SRAFrontend/Views/TaskPageView.axaml
@@ -12,23 +12,7 @@
     <Border Margin="10">
         <Grid RowDefinitions="Auto, *">
             <suki:GlassCard Content="{Binding ControlPanelViewModel}" />
-            <TabControl Grid.Row="1">
-                <TabItem Header="{x:Static lang:Resources.StartGameText}">
-                    <taskViews:StartGameView />
-                </TabItem>
-                <TabItem Header="{x:Static lang:Resources.TrailblazePowerText}">
-                    <taskViews:TrailblazePowerView />
-                </TabItem>
-                <TabItem Header="{x:Static lang:Resources.ReceiveRewardsText}">
-                    <taskViews:ReceiveRewardsView />
-                </TabItem>
-                <TabItem Header="{x:Static lang:Resources.CosmicStrifeText}">
-                    <taskViews:CosmicStrife />
-                </TabItem>
-                <TabItem Header="{x:Static lang:Resources.InTheEndText}">
-                    <taskViews:MissionAccomplishView />
-                </TabItem>
-            </TabControl>
+            <TabControl Grid.Row="1" x:Name="MainTabControl" />
         </Grid>
     </Border>
 </UserControl>

--- a/SRAFrontend/Views/TaskPageView.axaml.cs
+++ b/SRAFrontend/Views/TaskPageView.axaml.cs
@@ -1,11 +1,17 @@
-﻿using Avalonia.Controls;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using SRAFrontend.ViewModels;
+using SRAFrontend.Views.TaskViews;
 
 namespace SRAFrontend.Views;
 
 public partial class TaskPageView : UserControl
 {
+    private readonly Dictionary<string, UserControl> _viewCache = [];
+
     public TaskPageView()
     {
         InitializeComponent();
@@ -15,7 +21,82 @@ public partial class TaskPageView : UserControl
     {
         base.OnLoaded(e);
         if (DataContext is not TaskPageViewModel viewModel) return;
-        var topLevel = TopLevel.GetTopLevel(this);
-        viewModel.TopLevelObject = topLevel;
+
+        viewModel.TopLevelObject = TopLevel.GetTopLevel(this);
+
+        _viewCache["StartGameTask"] = new StartGameView { DataContext = viewModel };
+        _viewCache["TrailblazePowerTask"] = new TrailblazePowerView { DataContext = viewModel };
+        _viewCache["ReceiveRewardsTask"] = new ReceiveRewardsView { DataContext = viewModel };
+        _viewCache["CosmicStrifeTask"] = new CosmicStrife { DataContext = viewModel };
+        _viewCache["MissionAccomplishTask"] = new MissionAccomplishView { DataContext = viewModel };
+
+        viewModel.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(viewModel.OrderedTabKeys))
+                // 延迟执行，避免在按钮事件回调中直接清空控件树导致崩溃
+                Dispatcher.UIThread.Post(() => RebuildTabs(viewModel));
+        };
+
+        RebuildTabs(viewModel);
     }
+
+    private void RebuildTabs(TaskPageViewModel viewModel)
+    {
+        var tabControl = this.Find<TabControl>("MainTabControl");
+        if (tabControl == null) return;
+
+        var selectedKey = (tabControl.SelectedItem as TabItem)?.Tag as string;
+        var newOrder = viewModel.OrderedTabKeys;
+
+        // 增量更新：先确保所有 TabItem 存在，再按新顺序重排，不 Clear
+        // 1. 建立 key → TabItem 的映射
+        var existingItems = new Dictionary<string, TabItem>();
+        foreach (TabItem item in tabControl.Items)
+            if (item.Tag is string key)
+                existingItems[key] = item;
+
+        // 2. 添加缺少的 TabItem
+        foreach (var key in newOrder)
+        {
+            if (existingItems.ContainsKey(key)) continue;
+            if (!_viewCache.TryGetValue(key, out var view)) continue;
+            var header = KeyToHeader(key);
+            var newItem = new TabItem { Header = header, Content = view, Tag = key };
+            existingItems[key] = newItem;
+            tabControl.Items.Add(newItem);
+        }
+
+        // 3. 移除不在 newOrder 中的 TabItem
+        var toRemove = existingItems.Keys.Except(newOrder).ToList();
+        foreach (var key in toRemove)
+        {
+            tabControl.Items.Remove(existingItems[key]);
+            existingItems.Remove(key);
+        }
+
+        // 4. 按 newOrder 调整顺序（移动 TabItem 位置）
+        for (var i = 0; i < newOrder.Count; i++)
+        {
+            var key = newOrder[i];
+            if (!existingItems.TryGetValue(key, out var item)) continue;
+            var currentIdx = tabControl.Items.IndexOf(item);
+            if (currentIdx == i) continue;
+            tabControl.Items.Remove(item);
+            tabControl.Items.Insert(i, item);
+        }
+
+        // 5. 恢复选中
+        if (selectedKey != null && existingItems.TryGetValue(selectedKey, out var selected))
+            tabControl.SelectedItem = selected;
+    }
+
+    private static string KeyToHeader(string key) => key switch
+    {
+        "StartGameTask" => Localization.Resources.StartGameText,
+        "TrailblazePowerTask" => Localization.Resources.TrailblazePowerText,
+        "ReceiveRewardsTask" => Localization.Resources.ReceiveRewardsText,
+        "CosmicStrifeTask" => Localization.Resources.CosmicStrifeText,
+        "MissionAccomplishTask" => Localization.Resources.InTheEndText,
+        _ => key
+    };
 }

--- a/SRAFrontend/Views/TaskViews/CosmicStrife.axaml
+++ b/SRAFrontend/Views/TaskViews/CosmicStrife.axaml
@@ -11,7 +11,17 @@
         <suki:GroupBox>
             <suki:GroupBox.Header>
                 <StackPanel Orientation="Horizontal" Spacing="12">
-                    <CheckBox Content="旷宇纷争" IsChecked="{Binding CurrentConfig.EnabledTasks[3]}"/>
+                    <CheckBox Content="旷宇纷争" IsChecked="{Binding IsCosmicStrifeEnabled}"/>
+                    <Button Content="&lt;" Height="24" Width="28" Padding="4,0"
+                            IsEnabled="{Binding IsCosmicStrifeCanMoveLeft}"
+                            Command="{Binding MoveTaskLeftCommand}"
+                            CommandParameter="CosmicStrifeTask"
+                            ToolTip.Tip="提前执行"/>
+                    <Button Content="&gt;" Height="24" Width="28" Padding="4,0"
+                            IsEnabled="{Binding IsCosmicStrifeCanMoveRight}"
+                            Command="{Binding MoveTaskRightCommand}"
+                            CommandParameter="CosmicStrifeTask"
+                            ToolTip.Tip="推后执行"/>
                     <Button Content="&#xE3D0;" Classes="Flat Icon" Height="20" FontSize="14"
                             Command="{Binding SingleTaskCommand}"
                             CommandParameter="CosmicStrifeTask"

--- a/SRAFrontend/Views/TaskViews/MissionAccomplishView.axaml
+++ b/SRAFrontend/Views/TaskViews/MissionAccomplishView.axaml
@@ -11,7 +11,7 @@
         <suki:GroupBox>
             <suki:GroupBox.Header>
                 <StackPanel Orientation="Horizontal" Spacing="12">
-                    <CheckBox Content="任务完成后" IsChecked="{Binding CurrentConfig.EnabledTasks[4]}"/>
+                    <CheckBox Content="任务完成后" IsChecked="{Binding IsMissionAccomplishEnabled}"/>
                     <Button Content="&#xE3D0;" Classes="Flat Icon" Height="20" FontSize="14"
                             Command="{Binding SingleTaskCommand}"
                             CommandParameter="MissionAccomplishTask"

--- a/SRAFrontend/Views/TaskViews/ReceiveRewardsView.axaml
+++ b/SRAFrontend/Views/TaskViews/ReceiveRewardsView.axaml
@@ -11,7 +11,17 @@
         <suki:GroupBox>
             <suki:GroupBox.Header>
                 <StackPanel Orientation="Horizontal" Spacing="12">
-                    <CheckBox Content="领取奖励" IsChecked="{Binding CurrentConfig.EnabledTasks[2]}"/>
+                    <CheckBox Content="领取奖励" IsChecked="{Binding IsReceiveRewardsEnabled}"/>
+                    <Button Content="&lt;" Height="24" Width="28" Padding="4,0"
+                            IsEnabled="{Binding IsReceiveRewardsCanMoveLeft}"
+                            Command="{Binding MoveTaskLeftCommand}"
+                            CommandParameter="ReceiveRewardsTask"
+                            ToolTip.Tip="提前执行"/>
+                    <Button Content="&gt;" Height="24" Width="28" Padding="4,0"
+                            IsEnabled="{Binding IsReceiveRewardsCanMoveRight}"
+                            Command="{Binding MoveTaskRightCommand}"
+                            CommandParameter="ReceiveRewardsTask"
+                            ToolTip.Tip="推后执行"/>
                     <Button Content="&#xE3D0;" Classes="Flat Icon" Height="20" FontSize="14"
                             Command="{Binding SingleTaskCommand}"
                             CommandParameter="ReceiveRewardsTask"

--- a/SRAFrontend/Views/TaskViews/StartGameView.axaml
+++ b/SRAFrontend/Views/TaskViews/StartGameView.axaml
@@ -12,7 +12,7 @@
         <suki:GroupBox>
             <suki:GroupBox.Header>
                 <StackPanel Orientation="Horizontal" Spacing="12">
-                    <CheckBox Content="启动游戏" IsChecked="{Binding CurrentConfig.EnabledTasks[0]}"/>
+                    <CheckBox Content="启动游戏" IsChecked="{Binding IsStartGameEnabled}"/>
                     <Button Content="&#xE3D0;" Classes="Flat Icon" Height="20" FontSize="14"
                             Command="{Binding SingleTaskCommand}"
                             CommandParameter="StartGameTask"

--- a/SRAFrontend/Views/TaskViews/TaskViewSelector.cs
+++ b/SRAFrontend/Views/TaskViews/TaskViewSelector.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Metadata;
+
+namespace SRAFrontend.Views.TaskViews;
+
+/// <summary>
+///     根据任务类名（如 "StartGameTask"）选择对应的 TaskView。
+///     用于 TabControl 动态内容模板，实现 Tab 顺序跟随 TaskOrder 变化。
+/// </summary>
+public class TaskViewSelector : IDataTemplate
+{
+    [Content]
+    public Dictionary<string, IDataTemplate> Templates { get; } = new();
+
+    public Control? Build(object? param)
+    {
+        if (param is string key && Templates.TryGetValue(key, out var template))
+            return template.Build(param);
+        return null;
+    }
+
+    public bool Match(object? data) => data is string;
+}

--- a/SRAFrontend/Views/TaskViews/TrailblazePowerView.axaml
+++ b/SRAFrontend/Views/TaskViews/TrailblazePowerView.axaml
@@ -12,7 +12,17 @@
         <suki:GroupBox>
             <suki:GroupBox.Header>
                 <StackPanel Orientation="Horizontal" Spacing="12">
-                    <CheckBox Content="清体力" IsChecked="{Binding CurrentConfig.EnabledTasks[1]}"/>
+                    <CheckBox Content="清体力" IsChecked="{Binding IsTrailblazePowerEnabled}"/>
+                    <Button Content="&lt;" Height="24" Width="28" Padding="4,0"
+                            IsEnabled="{Binding IsTrailblazePowerCanMoveLeft}"
+                            Command="{Binding MoveTaskLeftCommand}"
+                            CommandParameter="TrailblazePowerTask"
+                            ToolTip.Tip="提前执行"/>
+                    <Button Content="&gt;" Height="24" Width="28" Padding="4,0"
+                            IsEnabled="{Binding IsTrailblazePowerCanMoveRight}"
+                            Command="{Binding MoveTaskRightCommand}"
+                            CommandParameter="TrailblazePowerTask"
+                            ToolTip.Tip="推后执行"/>
                     <Button Content="&#xE3D0;" Classes="Flat Icon" Height="20" FontSize="14"
                             Command="{Binding SingleTaskCommand}"
                             CommandParameter="TrailblazePowerTask"

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,13 +1,5 @@
-from .CosmicStrifeTask import CosmicStrifeTask
-from .MissionAccomplishTask import MissionAccomplishTask
-from .ReceiveRewardsTask import ReceiveRewardsTask
-from .StartGameTask import StartGameTask
-from .TrailblazePowerTask import TrailblazePowerTask
-
-__all__ = [
-    "CosmicStrifeTask",
-    "MissionAccomplishTask",
-    "ReceiveRewardsTask",
-    "StartGameTask",
-    "TrailblazePowerTask"
-]
+"""
+具体任务实现包。
+任务通过 SRACore/config.toml 声明，由 TaskManager 动态加载。
+不需要在此处手动 import。
+"""

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -183,12 +183,13 @@ def build_import_side_effect(task_map: dict[str, type]):
 
 @pytest.fixture
 def config_toml_path(tmp_path):
-    """创建测试用 config.toml（5 个标准任务）"""
+    """创建测试用 config.toml（5 个标准任务，含 fixed 字段）"""
     content = """
 [[tasks]]
 name = "启动游戏"
 main = "StartGameTask"
 module = "tasks.StartGameTask"
+fixed = "first"
 
 [[tasks]]
 name = "清开拓力"
@@ -209,6 +210,7 @@ module = "tasks.CosmicStrifeTask"
 name = "任务完成"
 main = "MissionAccomplishTask"
 module = "tasks.MissionAccomplishTask"
+fixed = "last"
 """
     config_file = tmp_path / "config.toml"
     config_file.write_text(content, encoding="utf-8")
@@ -218,23 +220,22 @@ module = "tasks.MissionAccomplishTask"
 @pytest.fixture
 def task_manager(config_toml_path):
     """创建使用测试配置的 TaskManager"""
-    from SRACore.thread.task_process import TaskManager
+    from SRACore.thread.task_process import TaskManager, TaskMeta
     with patch("importlib.import_module", side_effect=build_import_side_effect(TASK_MAP)):
         with patch("SRACore.thread.task_process.BaseTask", FakeBaseTask):
             mgr = TaskManager.__new__(TaskManager)
             mgr.log_level = "TRACE"
             mgr.log_queue = None
-            mgr.task_list = []
-            # 手动执行 __init__ 的核心逻辑
+            mgr.task_registry = {}
             import tomllib
             with open(config_toml_path, "rb") as f:
                 tasks = tomllib.load(f).get("tasks", [])
                 for task in tasks:
                     main_class = task.get("main")
-                    module_name = task.get("module")
-                    _module = MagicMock()
                     cls = TASK_MAP.get(main_class)
                     if cls:
-                        setattr(_module, main_class, cls)
-                    mgr.task_list.append(cls)
+                        mgr.task_registry[main_class] = TaskMeta(
+                            task_class=cls,
+                            fixed=task.get("fixed"),
+                        )
     return mgr

--- a/tests/backend/test_task_manager.py
+++ b/tests/backend/test_task_manager.py
@@ -23,7 +23,7 @@ class TestGetTasks:
 
     def test_all_enabled(self, task_manager):
         """所有任务启用时返回完整列表"""
-        config = {"EnabledTasks": [True, True, True, True, True]}
+        config = {"TaskOrder": ["StartGameTask", "TrailblazePowerTask", "ReceiveRewardsTask", "CosmicStrifeTask", "MissionAccomplishTask"]}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             with patch("SRACore.thread.task_process.Operator", MockOperator):
                 tasks = task_manager.get_tasks("test")
@@ -31,7 +31,7 @@ class TestGetTasks:
 
     def test_partial_enabled(self, task_manager):
         """部分启用时只返回选中的任务"""
-        config = {"EnabledTasks": [True, False, True, False, True]}
+        config = {"TaskOrder": ["StartGameTask", "ReceiveRewardsTask", "MissionAccomplishTask"]}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             with patch("SRACore.thread.task_process.Operator", MockOperator):
                 tasks = task_manager.get_tasks("test")
@@ -41,8 +41,8 @@ class TestGetTasks:
         assert isinstance(tasks[2], FakeMissionAccomplishTask)
 
     def test_none_enabled(self, task_manager):
-        """全部禁用时返回空列表"""
-        config = {"EnabledTasks": [False, False, False, False, False]}
+        """空 TaskOrder 时返回空列表"""
+        config = {"TaskOrder": []}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             tasks = task_manager.get_tasks("test")
         assert tasks == []
@@ -53,33 +53,17 @@ class TestGetTasks:
             tasks = task_manager.get_tasks("nonexistent")
         assert tasks == []
 
-    def test_no_enabled_tasks_field(self, task_manager):
-        """配置中缺少 EnabledTasks 字段时返回空列表"""
+    def test_no_task_order_field(self, task_manager):
+        """配置中缺少 TaskOrder 字段时返回空列表"""
         config = {"SomeOtherField": "value"}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             tasks = task_manager.get_tasks("test")
         assert tasks == []
 
-    def test_shorter_enabled_array(self, task_manager):
-        """EnabledTasks 长度不足时只处理有效部分"""
-        config = {"EnabledTasks": [True, True]}
-        with patch("SRACore.thread.task_process.load_config", return_value=config):
-            with patch("SRACore.thread.task_process.Operator", MockOperator):
-                tasks = task_manager.get_tasks("test")
-        assert len(tasks) == 2
-
-    def test_longer_enabled_array(self, task_manager):
-        """EnabledTasks 超出 task_list 长度时多余部分被忽略"""
-        config = {"EnabledTasks": [True, True, True, True, True, True, True]}
-        with patch("SRACore.thread.task_process.load_config", return_value=config):
-            with patch("SRACore.thread.task_process.Operator", MockOperator):
-                tasks = task_manager.get_tasks("test")
-        assert len(tasks) == 5  # 只有 5 个注册任务
-
     def test_password_hidden_in_log(self, task_manager):
         """验证密码在日志中被脱敏"""
         config = {
-            "EnabledTasks": [True],
+            "TaskOrder": ["StartGameTask"],
             "StartGamePassword": "my_secret_123"
         }
         with patch("SRACore.thread.task_process.load_config", return_value=config):
@@ -88,15 +72,17 @@ class TestGetTasks:
         # 原始 config 不应被修改（脱敏用的是 copy）
         assert config["StartGamePassword"] == "my_secret_123"
 
-    def test_execution_order_matches_enabled_tasks(self, task_manager):
-        """执行顺序与 EnabledTasks 索引顺序一致"""
-        config = {"EnabledTasks": [False, True, False, True, False]}
+    def test_execution_order_matches_task_order(self, task_manager):
+        """执行顺序与 TaskOrder 声明顺序一致"""
+        config = {"TaskOrder": ["StartGameTask", "CosmicStrifeTask", "TrailblazePowerTask", "MissionAccomplishTask"]}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             with patch("SRACore.thread.task_process.Operator", MockOperator):
                 tasks = task_manager.get_tasks("test")
-        assert len(tasks) == 2
-        assert isinstance(tasks[0], FakeTrailblazePowerTask)   # index 1
-        assert isinstance(tasks[1], FakeCosmicStrifeTask)      # index 3
+        assert len(tasks) == 4
+        assert isinstance(tasks[0], FakeStartGameTask)       # fixed=first
+        assert isinstance(tasks[1], FakeCosmicStrifeTask)    # 用户排序
+        assert isinstance(tasks[2], FakeTrailblazePowerTask) # 用户排序
+        assert isinstance(tasks[3], FakeMissionAccomplishTask) # fixed=last
 
 
 # ============================================================
@@ -107,12 +93,11 @@ class TestGetTask:
     """单任务查找测试"""
 
     def test_find_by_class_name(self, task_manager):
-        """按类名查找（命中 task_list 中的类）"""
+        """按类名查找（命中 task_registry 中的类）"""
         config = {}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             with patch("SRACore.thread.task_process.Operator", MockOperator):
-                # StartGameTask 在 task_list 中，通过 cls.__name__ 匹配
-                task = task_manager.get_task("test_config", "FakeStartGameTask")
+                task = task_manager.get_task("test_config", "StartGameTask")
         assert task is not None
         assert isinstance(task, FakeStartGameTask)
 
@@ -121,40 +106,20 @@ class TestGetTask:
         config = {}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             with patch("SRACore.thread.task_process.Operator", MockOperator):
-                task = task_manager.get_task("test_config", "fakestartgametask")
+                task = task_manager.get_task("test_config", "startgametask")
         assert task is not None
-
-    def test_find_by_index(self, task_manager):
-        """按索引查找"""
-        config = {}
-        with patch("SRACore.thread.task_process.load_config", return_value=config):
-            with patch("SRACore.thread.task_process.Operator", MockOperator):
-                task = task_manager.get_task("test_config", "0")
-        assert task is not None
-        assert isinstance(task, FakeStartGameTask)
-
-    def test_index_out_of_range(self, task_manager):
-        """索引越界返回 None"""
-        with patch("SRACore.thread.task_process.load_config", return_value={}):
-            task = task_manager.get_task("test", "99")
-        assert task is None
 
     def test_nonexistent_task(self, task_manager):
         """任务不存在返回 None（动态导入也找不到）"""
-        # 源码的 get_task 在按名称没有匹配到时，走 for...else 中的
-        # importlib.import_module("tasks.NoSuchTask") 分支。
-        # 这里需要让这个调用抛 ModuleNotFoundError。
-        # 由于直接 patch importlib 会影响 patch 机制本身，
-        # 我们直接构造一个场景让 get_task 返回 None：索引越界
         with patch("SRACore.thread.task_process.load_config", return_value={}):
-            task = task_manager.get_task("test", "99")  # 索引越界
+            with patch("SRACore.thread.task_process.importlib.import_module", side_effect=ModuleNotFoundError):
+                task = task_manager.get_task("test", "NoSuchTask")
         assert task is None
 
     def test_config_not_found(self, task_manager):
         """配置文件不存在返回 None"""
         with patch("SRACore.thread.task_process.load_config", return_value=None):
-            # 按类名查找命中 task_list，不走动态导入
-            task = task_manager.get_task("nonexistent", "FakeStartGameTask")
+            task = task_manager.get_task("nonexistent", "StartGameTask")
         assert task is None
 
 
@@ -167,7 +132,7 @@ class TestRun:
 
     def test_run_with_config_names(self, task_manager):
         """指定配置名执行"""
-        config = {"EnabledTasks": [True]}
+        config = {"TaskOrder": ["StartGameTask"]}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             with patch("SRACore.thread.task_process.Operator", MockOperator):
                 with patch("SRACore.thread.task_process.notify"):
@@ -175,7 +140,7 @@ class TestRun:
 
     def test_run_without_args_uses_cache(self, task_manager):
         """不指定配置时从缓存读取"""
-        config = {"EnabledTasks": [True]}
+        config = {"TaskOrder": ["StartGameTask"]}
         with patch("SRACore.thread.task_process.load_cache", return_value={"ConfigNames": ["c1"]}):
             with patch("SRACore.thread.task_process.load_config", return_value=config):
                 with patch("SRACore.thread.task_process.Operator", MockOperator):
@@ -183,16 +148,16 @@ class TestRun:
                         task_manager.run()
 
     def test_run_skips_empty_tasks(self, task_manager):
-        """空任务列表跳过该配置"""
-        config = {"EnabledTasks": []}
+        """空 TaskOrder 跳过该配置"""
+        config = {"TaskOrder": []}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             with patch("SRACore.thread.task_process.notify"):
                 task_manager.run("config1")
 
     def test_run_stops_on_failure(self, task_manager):
-        """任务返回 False 时终止"""
-        task_manager.task_list[0] = FakeFailingTask
-        config = {"EnabledTasks": [True, True]}
+        """任务失败时停止后续任务"""
+        task_manager.task_registry["StartGameTask"].task_class = FakeFailingTask
+        config = {"TaskOrder": ["StartGameTask"]}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             with patch("SRACore.thread.task_process.Operator", MockOperator):
                 with patch("SRACore.thread.task_process.notify"):
@@ -200,8 +165,8 @@ class TestRun:
 
     def test_run_handles_exception(self, task_manager):
         """任务抛异常时 break 不崩溃"""
-        task_manager.task_list[0] = FakeExplodingTask
-        config = {"EnabledTasks": [True]}
+        task_manager.task_registry["StartGameTask"].task_class = FakeExplodingTask
+        config = {"TaskOrder": ["StartGameTask"]}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             with patch("SRACore.thread.task_process.Operator", MockOperator):
                 with patch("SRACore.thread.task_process.notify"):
@@ -209,7 +174,7 @@ class TestRun:
 
     def test_run_multiple_configs(self, task_manager):
         """多配置依次执行"""
-        config = {"EnabledTasks": [True]}
+        config = {"TaskOrder": ["StartGameTask"]}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             with patch("SRACore.thread.task_process.Operator", MockOperator):
                 with patch("SRACore.thread.task_process.notify"):
@@ -229,20 +194,20 @@ class TestRunTask:
     """单任务执行测试"""
 
     def test_run_task_success(self, task_manager):
-        """成功执行单任务（按索引查找，避开动态导入）"""
+        """成功执行单任务"""
         config = {}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             with patch("SRACore.thread.task_process.Operator", MockOperator):
-                result = task_manager.run_task("0", "test")  # 用索引
+                result = task_manager.run_task("StartGameTask", "test")
         assert result is True
 
     def test_run_task_failure(self, task_manager):
         """任务返回 False"""
-        task_manager.task_list[0] = FakeFailingTask
+        task_manager.task_registry["StartGameTask"].task_class = FakeFailingTask
         config = {}
         with patch("SRACore.thread.task_process.load_config", return_value=config):
             with patch("SRACore.thread.task_process.Operator", MockOperator):
-                result = task_manager.run_task("0", "test")
+                result = task_manager.run_task("StartGameTask", "test")
         assert result is False
 
     def test_run_task_no_config(self, task_manager):
@@ -257,7 +222,7 @@ class TestRunTask:
         with patch("SRACore.thread.task_process.load_cache", return_value={"CurrentConfigName": "cached"}):
             with patch("SRACore.thread.task_process.load_config", return_value=config):
                 with patch("SRACore.thread.task_process.Operator", MockOperator):
-                    result = task_manager.run_task("0")  # 用索引
+                    result = task_manager.run_task("StartGameTask")
         assert result is True
 
     def test_run_task_not_found(self, task_manager):

--- a/tests/backend/test_task_manager_p0.py
+++ b/tests/backend/test_task_manager_p0.py
@@ -1,0 +1,218 @@
+"""
+P0 测试：TaskManager 重构 —— EnabledTasks → TaskOrder
+
+测试新的 task_registry + TaskOrder 机制。
+"""
+
+from dataclasses import dataclass
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from tests.backend.conftest import (
+    MockOperator, FakeBaseTask,
+    FakeStartGameTask, FakeTrailblazePowerTask, FakeReceiveRewardsTask,
+    FakeCosmicStrifeTask, FakeMissionAccomplishTask,
+    FakeFailingTask, TASK_MAP, build_import_side_effect,
+)
+
+
+# ============================================================
+# Fixtures：构建使用 fixed 字段的 config.toml + 新版 TaskManager
+# ============================================================
+
+TASK_MAP_WITH_FIXED = {
+    "StartGameTask": ("first", FakeStartGameTask),
+    "TrailblazePowerTask": (None, FakeTrailblazePowerTask),
+    "ReceiveRewardsTask": (None, FakeReceiveRewardsTask),
+    "CosmicStrifeTask": (None, FakeCosmicStrifeTask),
+    "MissionAccomplishTask": ("last", FakeMissionAccomplishTask),
+}
+
+
+@pytest.fixture
+def config_toml_with_fixed(tmp_path):
+    """创建带 fixed 字段的 config.toml"""
+    content = """
+[[tasks]]
+name = "启动游戏"
+main = "StartGameTask"
+module = "tasks.StartGameTask"
+fixed = "first"
+
+[[tasks]]
+name = "清开拓力"
+main = "TrailblazePowerTask"
+module = "tasks.TrailblazePowerTask"
+
+[[tasks]]
+name = "领取奖励"
+main = "ReceiveRewardsTask"
+module = "tasks.ReceiveRewardsTask"
+
+[[tasks]]
+name = "旷宇纷争"
+main = "CosmicStrifeTask"
+module = "tasks.CosmicStrifeTask"
+
+[[tasks]]
+name = "任务完成"
+main = "MissionAccomplishTask"
+module = "tasks.MissionAccomplishTask"
+fixed = "last"
+"""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(content, encoding="utf-8")
+    return str(config_file)
+
+
+@pytest.fixture
+def p0_task_manager(config_toml_with_fixed):
+    """创建使用新架构（task_registry + TaskMeta）的 TaskManager"""
+    from SRACore.thread.task_process import TaskManager, TaskMeta
+    with patch("importlib.import_module", side_effect=build_import_side_effect(TASK_MAP)):
+        with patch("SRACore.thread.task_process.BaseTask", FakeBaseTask):
+            mgr = TaskManager.__new__(TaskManager)
+            mgr.log_level = "TRACE"
+            mgr.log_queue = None
+            mgr.task_registry = {}
+            import tomllib
+            with open(config_toml_with_fixed, "rb") as f:
+                tasks = tomllib.load(f).get("tasks", [])
+                for task in tasks:
+                    main_class = task.get("main")
+                    cls = TASK_MAP.get(main_class)
+                    if cls:
+                        mgr.task_registry[main_class] = TaskMeta(
+                            task_class=cls,
+                            fixed=task.get("fixed"),
+                        )
+    return mgr
+
+
+# ============================================================
+# task_registry 基础测试
+# ============================================================
+
+class TestTaskRegistry:
+    """验证 TaskManager 使用 task_registry 替代 task_list"""
+
+    def test_registry_has_all_tasks(self, p0_task_manager):
+        """注册表应包含 config.toml 中所有任务"""
+        assert len(p0_task_manager.task_registry) == 5
+        assert "StartGameTask" in p0_task_manager.task_registry
+        assert "MissionAccomplishTask" in p0_task_manager.task_registry
+
+    def test_registry_stores_fixed_field(self, p0_task_manager):
+        """注册表应正确存储 fixed 字段"""
+        assert p0_task_manager.task_registry["StartGameTask"].fixed == "first"
+        assert p0_task_manager.task_registry["TrailblazePowerTask"].fixed is None
+        assert p0_task_manager.task_registry["MissionAccomplishTask"].fixed == "last"
+
+    def test_registry_stores_task_class(self, p0_task_manager):
+        """注册表应存储正确的任务类"""
+        assert p0_task_manager.task_registry["StartGameTask"].task_class is FakeStartGameTask
+        assert p0_task_manager.task_registry["CosmicStrifeTask"].task_class is FakeCosmicStrifeTask
+
+
+# ============================================================
+# get_tasks() 使用 TaskOrder 测试
+# ============================================================
+
+class TestGetTasksWithTaskOrder:
+    """验证 get_tasks() 使用 TaskOrder 替代 EnabledTasks"""
+
+    def test_task_order_determines_enabled_tasks(self, p0_task_manager):
+        """TaskOrder 中出现的任务 = 启用，顺序 = 执行顺序"""
+        config = {
+            "TaskOrder": [
+                "StartGameTask",
+                "ReceiveRewardsTask",
+                "MissionAccomplishTask",
+            ]
+        }
+        with patch("SRACore.thread.task_process.load_config", return_value=config):
+            with patch("SRACore.thread.task_process.Operator", MockOperator):
+                tasks = p0_task_manager.get_tasks("test")
+        assert len(tasks) == 3
+        assert isinstance(tasks[0], FakeStartGameTask)
+        assert isinstance(tasks[1], FakeReceiveRewardsTask)
+        assert isinstance(tasks[2], FakeMissionAccomplishTask)
+
+    def test_empty_task_order_returns_empty(self, p0_task_manager):
+        """空 TaskOrder 返回空列表"""
+        config = {"TaskOrder": []}
+        with patch("SRACore.thread.task_process.load_config", return_value=config):
+            tasks = p0_task_manager.get_tasks("test")
+        assert tasks == []
+
+    def test_unknown_task_in_order_is_skipped(self, p0_task_manager):
+        """TaskOrder 中包含未知任务名时跳过"""
+        config = {
+            "TaskOrder": [
+                "StartGameTask",
+                "NonExistentTask",
+                "MissionAccomplishTask",
+            ]
+        }
+        with patch("SRACore.thread.task_process.load_config", return_value=config):
+            with patch("SRACore.thread.task_process.Operator", MockOperator):
+                tasks = p0_task_manager.get_tasks("test")
+        assert len(tasks) == 2
+        assert isinstance(tasks[0], FakeStartGameTask)
+        assert isinstance(tasks[1], FakeMissionAccomplishTask)
+
+    def test_fixed_first_always_at_head(self, p0_task_manager):
+        """fixed=first 的任务无论 TaskOrder 中位置如何，始终排在最前"""
+        config = {
+            "TaskOrder": [
+                "ReceiveRewardsTask",
+                "StartGameTask",  # fixed=first，但放在中间
+                "MissionAccomplishTask",
+            ]
+        }
+        with patch("SRACore.thread.task_process.load_config", return_value=config):
+            with patch("SRACore.thread.task_process.Operator", MockOperator):
+                tasks = p0_task_manager.get_tasks("test")
+        assert isinstance(tasks[0], FakeStartGameTask)  # 必须在最前
+        assert isinstance(tasks[-1], FakeMissionAccomplishTask)  # 必须在最后
+
+    def test_fixed_last_always_at_tail(self, p0_task_manager):
+        """fixed=last 的任务无论 TaskOrder 中位置如何，始终排在最后"""
+        config = {
+            "TaskOrder": [
+                "MissionAccomplishTask",  # fixed=last，但放在最前
+                "TrailblazePowerTask",
+                "StartGameTask",
+            ]
+        }
+        with patch("SRACore.thread.task_process.load_config", return_value=config):
+            with patch("SRACore.thread.task_process.Operator", MockOperator):
+                tasks = p0_task_manager.get_tasks("test")
+        assert isinstance(tasks[0], FakeStartGameTask)  # first
+        assert isinstance(tasks[1], FakeTrailblazePowerTask)  # 中间
+        assert isinstance(tasks[-1], FakeMissionAccomplishTask)  # last
+
+    def test_user_order_preserved_for_non_fixed(self, p0_task_manager):
+        """非 fixed 任务的用户自定义顺序应被保留"""
+        config = {
+            "TaskOrder": [
+                "StartGameTask",
+                "CosmicStrifeTask",       # 用户把旷宇纷争放在清体力前面
+                "TrailblazePowerTask",
+                "ReceiveRewardsTask",
+                "MissionAccomplishTask",
+            ]
+        }
+        with patch("SRACore.thread.task_process.load_config", return_value=config):
+            with patch("SRACore.thread.task_process.Operator", MockOperator):
+                tasks = p0_task_manager.get_tasks("test")
+        # first 固定在头
+        assert isinstance(tasks[0], FakeStartGameTask)
+        # 用户自定义顺序
+        assert isinstance(tasks[1], FakeCosmicStrifeTask)
+        assert isinstance(tasks[2], FakeTrailblazePowerTask)
+        assert isinstance(tasks[3], FakeReceiveRewardsTask)
+        # last 固定在尾
+        assert isinstance(tasks[4], FakeMissionAccomplishTask)
+


### PR DESCRIPTION
## 背景

  当前任务系统使用 `EnabledTasks: bool[]` 通过数组索引与 `config.toml` 声明顺序绑定，存在以下问题：

  1. **静默错位**：`config.toml` 增删任务或调整顺序，所有存量用户配置对应关系失效
  2. **顺序不可调**：任务执行顺序完全由 `config.toml` 声明顺序决定，用户无法修改
  3. **前端 index 耦合**：5 处 XAML 硬编码 `EnabledTasks[0]~[4]`，与后端声明顺序强绑定

  ## 方案

  引入 `TaskOrder: string[]`（类名列表）替代 `bool[]`：
  - **出现在列表中 = 启用**，**顺序 = 执行顺序**
  - 用类名做标识，不依赖 index，增删任务不会错位
  - `fixed = "first"/"last"` 字段锁定首尾任务（StartGameTask/MissionAccomplishTask）

  ## 改动

  ### 后端
  | 文件 | 改动 |
  |------|------|
  | `SRACore/config.toml` | StartGameTask 加 `fixed="first"`，MissionAccomplishTask 加 `fixed="last"` |
  | `SRACore/thread/task_process.py` | `task_list` → `task_registry(dict[str,TaskMeta])`；`get_tasks()` 读 TaskOrder；新增 `_migrate_config()` |
  | `tasks/__init__.py` | 清除硬编码 import |

  ### 前端
  | 文件 | 改动 |
  |------|------|
  | `Models/Config.cs` | `bool[] EnabledTasks` → `List<string> TaskOrder`；`StaticVersion` 3→4；新增 `IsTaskEnabled/SetTaskEnabled` |
  | `Utils/DataPersister.cs` | `LoadConfig` 新增 V3→V4 迁移逻辑 |
  | `ViewModels/TaskPageViewModel.cs` | 新增 `IsXxxEnabled` 属性、`MoveTaskLeft/Right` 命令、Tab 动态排序 |
  | 5 个 TaskView AXAML | `EnabledTasks[n]` → `IsXxxEnabled` |
  | 3 个非 fixed TaskView | Header 增加 `<` `>` 排序按钮 |
  | `TaskPageView` | code-behind 动态构建 TabItem，Tab 顺序跟随 TaskOrder |

  ## 测试结果

  pytest tests/backend/ -v
  50 passed, 1 warning in 2.16s

  覆盖率：SRACore/thread/task_process.py 81%

  ## 效果

  用户可在任务 Tab 的标题栏通过 `<` `>` 按钮调整非固定任务的执行顺序，点击保存后生效，后端按 `TaskOrder` 顺序执行。固定任务（启动游戏、任务完成）始终锁定在首尾，不受排序影响。

效果图如下：
<img width="1792" height="1048" alt="image" src="https://github.com/user-attachments/assets/c97786b1-186c-419d-8712-4384648fb608" />

<img width="1790" height="1048" alt="image" src="https://github.com/user-attachments/assets/f645e4c9-1021-4083-be72-9eae177e3843" />
