### PR TITLE
feat: 新增外部通知渠道支持（Webhook / Telegram / ServerChan / OneBot）

### DIFF
--- a/SRACore/cli.py
+++ b/SRACore/cli.py
@@ -268,7 +268,7 @@ class SRACli(cmd.Cmd):
         print(f"{VERSION}")
 
     def do_notify(self, arg: str):
-        """Notification command - support test email notification"""
+        """Notification command - support test email/webhook/telegram/serverchan/onebot notification"""
         args = arg.split()
         if not args:
             print(Resource.cli_invalidArguments('notify'))
@@ -278,6 +278,32 @@ class SRACli(cmd.Cmd):
         if command == 'test-email':
             from SRACore.util.notify import send_test_email
             send_test_email()
+        elif command == 'test' and len(args) >= 2:
+            channel = args[1]
+            from SRACore.util.data_persister import load_settings
+            from SRACore.util.notify import (
+                _build_notification_data,
+                send_webhook_notification,
+                send_telegram_notification,
+                send_serverchan_notification,
+                send_onebot_notification,
+            )
+            settings = load_settings()
+            data = _build_notification_data("notify.test", "这是一条测试通知", "success")
+            if channel == 'webhook':
+                result = send_webhook_notification(data, settings)
+                print("Webhook 测试通知发送" + ("成功" if result else "失败"))
+            elif channel == 'telegram':
+                result = send_telegram_notification(data, settings)
+                print("Telegram 测试通知发送" + ("成功" if result else "失败"))
+            elif channel == 'serverchan':
+                result = send_serverchan_notification(data, settings)
+                print("ServerChan 测试通知发送" + ("成功" if result else "失败"))
+            elif channel == 'onebot':
+                result = send_onebot_notification(data, settings)
+                print("OneBot 测试通知发送" + ("成功" if result else "失败"))
+            else:
+                print(Resource.cli_invalidArguments('notify'))
         else:
             print(Resource.cli_invalidArguments('notify'))
 

--- a/SRACore/thread/task_process.py
+++ b/SRACore/thread/task_process.py
@@ -88,10 +88,20 @@ class TaskManager:
                         if not task.run():
                             logger.debug('task failed: ' + str(task))
                             logger.error(Resource.task_taskFailed(str(task)))
+                            notify.try_send_notification(
+                                Resource.task_notificationTitle,
+                                Resource.task_taskFailed(str(task)),
+                                result="fail"
+                            )
                             return  # 终止当前配置的执行
                     except Exception as e:
                         # 捕获任务执行中的异常（如未处理的错误）
                         logger.exception(Resource.task_taskCrashed(str(task), str(e)))
+                        notify.try_send_notification(
+                            Resource.task_notificationTitle,
+                            Resource.task_taskCrashed(str(task), str(e)),
+                            result="fail"
+                        )
                         break
                 logger.info(Resource.task_configCompleted(config_name))
                 logger.info("=" * 50)
@@ -185,6 +195,11 @@ class TaskManager:
             return result
         except Exception as e:
             logger.exception(Resource.task_taskCrashed(task, str(e)))
+            notify.try_send_notification(
+                Resource.task_notificationTitle,
+                Resource.task_taskCrashed(str(task), str(e)),
+                result="fail"
+            )
             return False
         finally:
             logger.debug("[Done]")

--- a/SRACore/util/notify.py
+++ b/SRACore/util/notify.py
@@ -1,4 +1,10 @@
+import json
+import re
 import smtplib
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime
 from email.mime.text import MIMEText
 from email.utils import formataddr
 from typing import Any
@@ -7,9 +13,10 @@ from plyer import notification # type: ignore
 
 from SRACore.util import encryption
 from SRACore.util.data_persister import load_settings
+from SRACore.util.logger import logger
 
 
-def try_send_notification(title: str, message: str):
+def try_send_notification(title: str, message: str, result: str = "success"):
     setting = load_settings()
     if not setting.get('AllowNotifications', False):
         return
@@ -17,6 +24,22 @@ def try_send_notification(title: str, message: str):
         send_windows_notification(title, message)
     if setting.get('AllowEmailNotifications', False):
         send_mail_notification(title, message, setting)
+
+    if setting.get("AllowWebhookNotifications", False):
+        data = _build_notification_data(title, message, result)
+        send_webhook_notification(data, setting)
+
+    if setting.get("AllowTelegramNotifications", False):
+        data = _build_notification_data(title, message, result)
+        send_telegram_notification(data, setting)
+
+    if setting.get("AllowServerChanNotifications", False):
+        data = _build_notification_data(title, message, result)
+        send_serverchan_notification(data, setting)
+
+    if setting.get("AllowOneBotNotifications", False):
+        data = _build_notification_data(title, message, result)
+        send_onebot_notification(data, setting)
 
 
 def send_windows_notification(title: str, message: str, timeout: int = 5):
@@ -116,3 +139,228 @@ def send_test_email() -> bool:
     except Exception as e:
         print(f"测试邮件发送失败: {e}")
         return False
+
+
+# =================== 通知数据构造 ===================
+
+def _build_notification_data(title: str, message: str, result: str = "success") -> dict:
+    return {
+        "event": title,
+        "result": result,
+        "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "message": message,
+    }
+
+
+def _http_post_json(url: str, payload: dict, timeout: int = 10,
+                    proxy_url: str | None = None) -> tuple[int, str]:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json", "User-Agent": "StarRailAssistant/1.0"},
+        method="POST",
+    )
+    if proxy_url:
+        handler = urllib.request.ProxyHandler({"http": proxy_url, "https": proxy_url})
+        opener = urllib.request.build_opener(handler)
+    else:
+        opener = urllib.request.build_opener()
+    try:
+        with opener.open(req, timeout=timeout) as resp:
+            return resp.status, resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", errors="replace")
+
+
+def _http_post_form(url: str, payload: dict, timeout: int = 10) -> tuple[int, str]:
+    data = urllib.parse.urlencode(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": "StarRailAssistant/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", errors="replace")
+
+
+# =================== Webhook 通知 ===================
+
+def send_webhook_notification(data: dict, configure: dict[str, Any] | None = None) -> bool:
+    config = configure or {}
+    endpoint = config.get("WebhookEndpoint", "").strip()
+    if not endpoint:
+        logger.warning("Webhook 通知发送失败: 未配置 WebhookEndpoint")
+        return False
+    try:
+        status, body = _http_post_json(endpoint, data)
+        if 200 <= status < 300:
+            logger.debug(f"Webhook 通知发送成功: {endpoint}")
+            return True
+        else:
+            logger.warning(f"Webhook 通知发送失败，状态码: {status}，响应: {body[:200]}")
+            return False
+    except Exception as e:
+        logger.warning(f"Webhook 通知发送失败: {e}")
+        return False
+
+
+# =================== Telegram 通知 ===================
+
+def send_telegram_notification(data: dict, configure: dict[str, Any] | None = None) -> bool:
+    config = configure or {}
+    bot_token = config.get("TelegramBotToken", "").strip()
+    chat_id = config.get("TelegramChatId", "").strip()
+    proxy_url = config.get("TelegramProxyUrl", "").strip()
+    proxy_enabled = config.get("TelegramProxyEnabled", False)
+    api_base = config.get("TelegramApiBaseUrl", "").strip()
+    if not bot_token:
+        logger.warning("Telegram 通知发送失败: 未配置 TelegramBotToken")
+        return False
+    if not chat_id:
+        logger.warning("Telegram 通知发送失败: 未配置 TelegramChatId")
+        return False
+    if not api_base:
+        api_base = "https://api.telegram.org/bot"
+    else:
+        if not api_base.startswith(("http://", "https://")):
+            api_base = "https://" + api_base
+        if not api_base.endswith("/"):
+            api_base += "/"
+        if not api_base.endswith("/bot"):
+            api_base += "bot"
+    endpoint = f"{api_base}{bot_token}/sendMessage"
+    message = (
+        f"[SRA 通知]\n"
+        f"事件: {data.get('event', '')}\n"
+        f"结果: {data.get('result', '')}\n"
+        f"时间: {data.get('timestamp', '')}\n"
+        f"消息: {data.get('message', '')}"
+    )
+    effective_proxy = proxy_url if proxy_enabled and proxy_url else None
+    try:
+        status, body = _http_post_json(
+            endpoint,
+            {"chat_id": chat_id, "text": message, "disable_web_page_preview": True},
+            proxy_url=effective_proxy,
+        )
+        if 200 <= status < 300:
+            logger.debug(f"Telegram 通知发送成功: chat_id={chat_id}")
+            return True
+        else:
+            logger.warning(f"Telegram 通知发送失败，状态码: {status}，响应: {body[:200]}")
+            return False
+    except Exception as e:
+        logger.warning(f"Telegram 通知发送失败: {e}")
+        return False
+
+
+# =================== ServerChan 通知 ===================
+
+def send_serverchan_notification(data: dict, configure: dict[str, Any] | None = None) -> bool:
+    config = configure or {}
+    send_key = config.get("ServerChanSendKey", "").strip()
+    if not send_key:
+        logger.warning("ServerChan 通知发送失败: 未配置 ServerChanSendKey")
+        return False
+    if send_key.startswith("sctp"):
+        match = re.match(r"^sctp(\d+)t", send_key)
+        if not match:
+            logger.warning("ServerChan 通知发送失败: SendKey 格式无效")
+            return False
+        num = match.group(1)
+        api_url = f"https://{num}.push.ft07.com/send/{send_key}.send"
+    else:
+        api_url = f"https://sctapi.ftqq.com/{send_key}.send"
+    title = "SRA 通知"
+    desp = (
+        f"**时间**: {data.get('timestamp', '')}\n\n"
+        f"**事件**: {data.get('event', '')}\n\n"
+        f"**结果**: {data.get('result', '')}\n\n"
+        f"**消息**: {data.get('message', '')}"
+    )
+    try:
+        status, body = _http_post_form(api_url, {"title": title, "desp": desp})
+        if 200 <= status < 300:
+            logger.debug("ServerChan 通知发送成功")
+            return True
+        else:
+            logger.warning(f"ServerChan 通知发送失败，状态码: {status}，响应: {body[:200]}")
+            return False
+    except Exception as e:
+        logger.warning(f"ServerChan 通知发送失败: {e}")
+        return False
+
+
+# =================== OneBot 通知 ===================
+
+def send_onebot_notification(data: dict, configure: dict[str, Any] | None = None) -> bool:
+    config = configure or {}
+    endpoint = config.get("OneBotEndpoint", "").strip().rstrip("/")
+    user_id = config.get("OneBotUserId", "").strip()
+    group_id = config.get("OneBotGroupId", "").strip()
+    token = config.get("OneBotToken", "").strip()
+    if not endpoint:
+        logger.warning("OneBot 通知发送失败: 未配置 OneBotEndpoint")
+        return False
+    if not user_id and not group_id:
+        logger.warning("OneBot 通知发送失败: OneBotUserId 和 OneBotGroupId 至少需要填写一个")
+        return False
+    url = endpoint if endpoint.endswith("/send_msg") else endpoint + "/send_msg"
+    message_text = (
+        f"[SRA 通知]\n"
+        f"事件: {data.get('event', '')}\n"
+        f"结果: {data.get('result', '')}\n"
+        f"时间: {data.get('timestamp', '')}\n"
+        f"消息: {data.get('message', '')}"
+    )
+    message_content = [{"type": "text", "data": {"text": message_text}}]
+    success = True
+    if user_id:
+        ok = _onebot_send(url, {"message_type": "private", "user_id": user_id, "message": message_content}, token)
+        if not ok:
+            success = False
+    if group_id:
+        ok = _onebot_send(url, {"message_type": "group", "group_id": group_id, "message": message_content}, token)
+        if not ok:
+            success = False
+    return success
+
+
+def _onebot_send(url: str, payload: dict, token: str) -> bool:
+    data = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json", "User-Agent": "StarRailAssistant/1.0"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            status = resp.status
+            body = resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        status = e.code
+        body = e.read().decode("utf-8", errors="replace")
+    except Exception as e:
+        logger.warning(f"OneBot 通知发送失败: {e}")
+        return False
+    if not (200 <= status < 300):
+        logger.warning(f"OneBot 通知发送失败，状态码: {status}，响应: {body[:200]}")
+        return False
+    try:
+        resp_json = json.loads(body)
+        if resp_json.get("status") == "ok":
+            logger.debug(f"OneBot 通知发送成功: {url}")
+            return True
+        else:
+            logger.warning(f"OneBot 通知发送失败，响应: {body[:200]}")
+            return False
+    except Exception:
+        logger.debug(f"OneBot 通知发送成功（非标准响应）: {url}")
+        return True

--- a/SRAFrontend/Models/Settings.cs
+++ b/SRAFrontend/Models/Settings.cs
@@ -63,7 +63,7 @@ public partial class Settings : ObservableObject
 
     [JsonPropertyName("MirrorChyanCdk")] public string EncryptedMirrorChyanCdk { get; set; } = "";
     [JsonPropertyName("EmailAuthCode")] public string EncryptedEmailAuthCode { get; set; } = "";
-    public const string Version = "2.10.0"; // 应用版本号
+    public const string Version = "2.9.0"; // 应用版本号
 
     // 新增快捷键设置
     public string ActivityHotkey { get; set; } = "F1"; // 活动 默认 F1
@@ -73,5 +73,28 @@ public partial class Settings : ObservableObject
     public string MapHotkey { get; set; } = "M"; // 地图 默认 M
     public string TechniqueHotkey { get; set; } = "E"; // 秘技 默认 E
     public string StartStopHotkey { get; set; } = "F9"; // 启动/停止 默认 F9
+
+    // Webhook 通知
+    [ObservableProperty] private bool _allowWebhookNotifications;
+    [ObservableProperty] private string _webhookEndpoint = "";
+
+    // Telegram 通知
+    [ObservableProperty] private bool _allowTelegramNotifications;
+    [ObservableProperty] private string _telegramBotToken = "";
+    [ObservableProperty] private string _telegramChatId = "";
+    [ObservableProperty] private bool _telegramProxyEnabled;
+    [ObservableProperty] private string _telegramProxyUrl = "http://127.0.0.1:7890";
+    [ObservableProperty] private string _telegramApiBaseUrl = "";
+
+    // ServerChan 通知
+    [ObservableProperty] private bool _allowServerChanNotifications;
+    [ObservableProperty] private string _serverChanSendKey = "";
+
+    // OneBot 通知
+    [ObservableProperty] private bool _allowOneBotNotifications;
+    [ObservableProperty] private string _oneBotEndpoint = "";
+    [ObservableProperty] private string _oneBotUserId = "";
+    [ObservableProperty] private string _oneBotGroupId = "";
+    [ObservableProperty] private string _oneBotToken = "";
 
 }

--- a/SRAFrontend/ViewModels/SettingsPageViewModel.cs
+++ b/SRAFrontend/ViewModels/SettingsPageViewModel.cs
@@ -18,6 +18,7 @@ public partial class SettingsPageViewModel : PageViewModel
     private readonly CommonModel _commonModel;
     private readonly AvaloniaList<CustomizableKey> _customizableKeys;
     private readonly RegistryService _registryService;
+    private readonly IBackendService _backendService;
 
     private readonly SettingsService _settingsService;
     private readonly UpdateService _updateService;
@@ -28,7 +29,8 @@ public partial class SettingsPageViewModel : PageViewModel
         UpdateService updateService,
         CacheService cacheService,
         CommonModel commonModel,
-        RegistryService registryService
+        RegistryService registryService,
+        IBackendService backendService
     ) : base(PageName.Setting,
         "\uE272")
     {
@@ -37,6 +39,7 @@ public partial class SettingsPageViewModel : PageViewModel
         _cacheService = cacheService;
         _registryService = registryService;
         _commonModel = commonModel;
+        _backendService = backendService;
         // 任务通用设置中的 启动/停止 快捷键（非游戏内快捷键分组）
         StartStopKey = new CustomizableKey(ListenKeyFor)
         {
@@ -230,6 +233,73 @@ public partial class SettingsPageViewModel : PageViewModel
     private async Task TestEmail()
     {
         await _commonModel.SendTestEmailAsync();
+    }
+
+    [RelayCommand]
+    private void TestWebhook()
+    {
+        var endpoint = Settings.WebhookEndpoint?.Trim();
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            _commonModel.ShowErrorToast("Webhook 测试", "请先填写 Webhook 地址");
+            return;
+        }
+        _ = _backendService.SendInput("notify test webhook");
+        _commonModel.ShowInfoToast("Webhook 测试", $"测试请求已发送至：{endpoint}");
+    }
+
+    [RelayCommand]
+    private void TestTelegram()
+    {
+        if (string.IsNullOrEmpty(Settings.TelegramBotToken?.Trim()))
+        {
+            _commonModel.ShowErrorToast("Telegram 测试", "请先填写 Bot Token");
+            return;
+        }
+        if (string.IsNullOrEmpty(Settings.TelegramChatId?.Trim()))
+        {
+            _commonModel.ShowErrorToast("Telegram 测试", "请先填写 Chat ID");
+            return;
+        }
+        _ = _backendService.SendInput("notify test telegram");
+        _commonModel.ShowInfoToast("Telegram 测试", "测试消息已发送，请检查 Telegram");
+    }
+
+    [RelayCommand]
+    private void TestServerChan()
+    {
+        if (string.IsNullOrEmpty(Settings.ServerChanSendKey?.Trim()))
+        {
+            _commonModel.ShowErrorToast("ServerChan 测试", "请先填写 SendKey");
+            return;
+        }
+        _ = _backendService.SendInput("notify test serverchan");
+        _commonModel.ShowInfoToast("ServerChan 测试", "测试消息已发送，请检查微信");
+    }
+
+    [RelayCommand]
+    private void SaveNotificationSettings()
+    {
+        _settingsService.SaveSettings();
+        _commonModel.ShowSuccessToast("保存成功", "通知设置已保存");
+    }
+
+    [RelayCommand]
+    private void TestOneBot()
+    {
+        if (string.IsNullOrEmpty(Settings.OneBotEndpoint?.Trim()))
+        {
+            _commonModel.ShowErrorToast("OneBot 测试", "请先填写 API 地址");
+            return;
+        }
+        if (string.IsNullOrEmpty(Settings.OneBotUserId?.Trim()) &&
+            string.IsNullOrEmpty(Settings.OneBotGroupId?.Trim()))
+        {
+            _commonModel.ShowErrorToast("OneBot 测试", "请填写 QQ 号或群号（至少一个）");
+            return;
+        }
+        _ = _backendService.SendInput("notify test onebot");
+        _commonModel.ShowInfoToast("OneBot 测试", "测试消息已发送，请检查 QQ");
     }
 
     #region 快捷键监听修改逻辑

--- a/SRAFrontend/Views/SettingsPageView.axaml
+++ b/SRAFrontend/Views/SettingsPageView.axaml
@@ -284,6 +284,149 @@
                                             </Expander>
                                         </StackPanel>
                                     </Expander>
+
+                                    <!-- Webhook 通知 -->
+                                    <Grid ColumnDefinitions="*,Auto">
+                                        <CheckBox Grid.Column="0"
+                                                  Content="Webhook 通知"
+                                                  IsChecked="{Binding Settings.AllowWebhookNotifications}" />
+                                        <Button Grid.Column="1"
+                                                Content="Check"
+                                                Margin="10,0,0,0"
+                                                Command="{Binding TestWebhookCommand}"
+                                                IsEnabled="{Binding Settings.AllowWebhookNotifications}" />
+                                    </Grid>
+                                    <Expander Header="Webhook 设置"
+                                              IsVisible="{Binding Settings.AllowWebhookNotifications}">
+                                        <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
+                                            <Label Grid.Row="0" Grid.Column="0"
+                                                   VerticalAlignment="Center"
+                                                   Content="推送地址" />
+                                            <TextBox Grid.Row="0" Grid.Column="1"
+                                                     Text="{Binding Settings.WebhookEndpoint}"
+                                                     Watermark="https://your-webhook-endpoint" />
+                                        </Grid>
+                                    </Expander>
+
+                                    <!-- Telegram 通知 -->
+                                    <Grid ColumnDefinitions="*,Auto">
+                                        <CheckBox Grid.Column="0"
+                                                  Content="Telegram 通知"
+                                                  IsChecked="{Binding Settings.AllowTelegramNotifications}" />
+                                        <Button Grid.Column="1"
+                                                Content="Check"
+                                                Margin="10,0,0,0"
+                                                Command="{Binding TestTelegramCommand}"
+                                                IsEnabled="{Binding Settings.AllowTelegramNotifications}" />
+                                    </Grid>
+                                    <Expander Header="Telegram 设置"
+                                              IsVisible="{Binding Settings.AllowTelegramNotifications}">
+                                        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*"
+                                              RowSpacing="6">
+                                            <Label Grid.Row="0" Grid.Column="0"
+                                                   VerticalAlignment="Center"
+                                                   Content="Bot Token" />
+                                            <TextBox Grid.Row="0" Grid.Column="1"
+                                                     Text="{Binding Settings.TelegramBotToken}"
+                                                     Watermark="1234567890:ABCdef..." />
+                                            <Label Grid.Row="1" Grid.Column="0"
+                                                   VerticalAlignment="Center"
+                                                   Content="Chat ID" />
+                                            <TextBox Grid.Row="1" Grid.Column="1"
+                                                     Text="{Binding Settings.TelegramChatId}"
+                                                     Watermark="-1001234567890" />
+                                            <Label Grid.Row="2" Grid.Column="0"
+                                                   VerticalAlignment="Center"
+                                                   Content="自定义 API 地址" />
+                                            <TextBox Grid.Row="2" Grid.Column="1"
+                                                     Text="{Binding Settings.TelegramApiBaseUrl}"
+                                                     Watermark="留空使用官方 API" />
+                                            <Label Grid.Row="3" Grid.Column="0"
+                                                   VerticalAlignment="Center"
+                                                   Content="启用代理" />
+                                            <ToggleSwitch Grid.Row="3" Grid.Column="1"
+                                                          IsChecked="{Binding Settings.TelegramProxyEnabled}" />
+                                            <Label Grid.Row="4" Grid.Column="0"
+                                                   VerticalAlignment="Center"
+                                                   IsVisible="{Binding Settings.TelegramProxyEnabled}"
+                                                   Content="代理地址" />
+                                            <TextBox Grid.Row="4" Grid.Column="1"
+                                                     IsVisible="{Binding Settings.TelegramProxyEnabled}"
+                                                     Text="{Binding Settings.TelegramProxyUrl}"
+                                                     Watermark="http://127.0.0.1:7890" />
+                                        </Grid>
+                                    </Expander>
+
+                                    <!-- ServerChan 通知 -->
+                                    <Grid ColumnDefinitions="*,Auto">
+                                        <CheckBox Grid.Column="0"
+                                                  Content="ServerChan 微信通知"
+                                                  IsChecked="{Binding Settings.AllowServerChanNotifications}" />
+                                        <Button Grid.Column="1"
+                                                Content="Check"
+                                                Margin="10,0,0,0"
+                                                Command="{Binding TestServerChanCommand}"
+                                                IsEnabled="{Binding Settings.AllowServerChanNotifications}" />
+                                    </Grid>
+                                    <Expander Header="ServerChan 设置"
+                                              IsVisible="{Binding Settings.AllowServerChanNotifications}">
+                                        <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
+                                            <Label Grid.Row="0" Grid.Column="0"
+                                                   VerticalAlignment="Center"
+                                                   Content="SendKey" />
+                                            <TextBox Grid.Row="0" Grid.Column="1"
+                                                     Text="{Binding Settings.ServerChanSendKey}"
+                                                     Watermark="SCT... 或 sctp..." />
+                                        </Grid>
+                                    </Expander>
+
+                                    <!-- OneBot 通知 -->
+                                    <Grid ColumnDefinitions="*,Auto">
+                                        <CheckBox Grid.Column="0"
+                                                  Content="OneBot QQ 通知"
+                                                  IsChecked="{Binding Settings.AllowOneBotNotifications}" />
+                                        <Button Grid.Column="1"
+                                                Content="Check"
+                                                Margin="10,0,0,0"
+                                                Command="{Binding TestOneBotCommand}"
+                                                IsEnabled="{Binding Settings.AllowOneBotNotifications}" />
+                                    </Grid>
+                                    <Expander Header="OneBot 设置"
+                                              IsVisible="{Binding Settings.AllowOneBotNotifications}">
+                                        <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*"
+                                              RowSpacing="6">
+                                            <Label Grid.Row="0" Grid.Column="0"
+                                                   VerticalAlignment="Center"
+                                                   Content="API 地址" />
+                                            <TextBox Grid.Row="0" Grid.Column="1"
+                                                     Text="{Binding Settings.OneBotEndpoint}"
+                                                     Watermark="http://127.0.0.1:3000" />
+                                            <Label Grid.Row="1" Grid.Column="0"
+                                                   VerticalAlignment="Center"
+                                                   Content="QQ 号（私聊）" />
+                                            <TextBox Grid.Row="1" Grid.Column="1"
+                                                     Text="{Binding Settings.OneBotUserId}"
+                                                     Watermark="留空则不发送私聊" />
+                                            <Label Grid.Row="2" Grid.Column="0"
+                                                   VerticalAlignment="Center"
+                                                   Content="群号（群聊）" />
+                                            <TextBox Grid.Row="2" Grid.Column="1"
+                                                     Text="{Binding Settings.OneBotGroupId}"
+                                                     Watermark="留空则不发送群聊" />
+                                            <Label Grid.Row="3" Grid.Column="0"
+                                                   VerticalAlignment="Center"
+                                                   Content="AccessToken" />
+                                            <TextBox Grid.Row="3" Grid.Column="1"
+                                                     Text="{Binding Settings.OneBotToken}"
+                                                     Watermark="留空则不使用认证" />
+                                        </Grid>
+                                    </Expander>
+
+                                    <!-- 通知设置保存按钮 -->
+                                    <Button Content="保存通知设置"
+                                            HorizontalAlignment="Left"
+                                            Command="{Binding SaveNotificationSettingsCommand}" />
+
                                     <!-- <Grid ColumnDefinitions="Auto,*,Auto"> -->
                                     <!-- <Label Grid.Column="0" Classes="Icon">&#xe0f4;</Label> -->
                                     <!-- <Label Grid.Column="1" Content="{x:Static lang:Resources.DefaultPageText}" /> -->


### PR DESCRIPTION
变更说明
新增四种外部通知渠道，任务完成或失败时推送通知，参考 BetterGI 通知系统设计。
变更内容
后端

notify.py：新增 Webhook、Telegram、ServerChan、OneBot 四个渠道，使用标准库 urllib，无额外依赖
cli.py：扩展 do_notify，支持 notify test <channel> 测试命令
task_process.py：任务失败/异常时补充失败通知

前端

Settings.cs：新增各渠道配置属性
SettingsPageViewModel.cs：新增各渠道测试命令及保存命令
SettingsPageView.axaml：新增各渠道配置 UI 及保存按钮

说明

全部使用标准库，兼容 Nuitka 打包
原有通知逻辑不受影响
通知失败仅输出 WARNING，不影响任务执行