### PR TITLE
fix: 延长货币战争攻略码确认等待时间

### DIFF
--- a/tasks/currency_wars/CurrencyWars.py
+++ b/tasks/currency_wars/CurrencyWars.py
@@ -395,7 +395,7 @@ class CurrencyWars(Executable):
             self.operator.copy(self.strategy_code)
             self.operator.paste()
             self.operator.sleep(1)
-            self.operator.click_img(IMG.ENSURE2, after_sleep=1)
+            self.operator.click_img(IMG.ENSURE2, after_sleep=5)
             self.operator.click_img(CWIMG.APPLY_STRATEGY, after_sleep=1)
             self.operator.press_key('esc', presses=3, interval=1)
         return True


### PR DESCRIPTION
## Summary
- 延长货币战争应用攻略码后确认按钮的等待时间，减少界面尚未稳定就继续点击导致导入失败的情况
- 保持现有导入流程不变，仅调整这一处低风险时序

## Verification
- python -m py_compile tasks/currency_wars/CurrencyWars.py