### PR TITLE
fix: 调整货币战争卖牌优先级并回补攻略次数

### DIFF
--- a/tasks/currency_wars/CurrencyWars.py
+++ b/tasks/currency_wars/CurrencyWars.py
@@ -7,6 +7,7 @@ from loguru import logger
 from SRACore.task import Executable
 from SRACore.util.errors import ErrorCode, SRAError
 from tasks.currency_wars.characters import Character, Characters, Positioning
+from tasks.currency_wars.sell_logic import build_sell_plan, settle_sold_character
 from tasks.img import CWIMG, IMG
 
 
@@ -614,27 +615,39 @@ class CurrencyWars(Executable):
         角色出售逻辑
         :param force: bool - 是否强制出售所有角色（包括已放置的角色）
         """
-        # 创建需要出售的角色索引列表
-        characters_to_sell: list[tuple[int, Character]] = []
-        for i, character in enumerate(self.in_hand_character):
-            if character is None:
-                continue
-            if force:
-                characters_to_sell.append((i, character))
-            elif not character.is_placed:
-                characters_to_sell.append((i, character))
+        characters_to_sell = build_sell_plan(
+            self.in_hand_character,
+            self.strategy_characters,
+            force=force,
+        )
 
-        # 执行出售操作
+        if not characters_to_sell:
+            logger.info("当前没有可出售的角色")
+            return
+
         for i, character in characters_to_sell:
+            logger.info(
+                f"计划出售角色[{i}]：{character.name} "
+                f"(攻略角色={character.name in self.strategy_characters}, "
+                f"已上场={character.is_placed}, priority={character.priority})"
+            )
             # 由于商店区域没有角色列表，直接执行拖拽
             sell_area = (0.05, 0.86)  # 出售区域
             source = self.in_hand_area[i]
             self.operator.drag_to(source[0], source[1], sell_area[0], sell_area[1])
             # 更新手牌状态
             self.in_hand_character[i] = None
-            if character:
-                character.is_placed = False
+            refunded = settle_sold_character(
+                character,
+                self.strategy_characters,
+                self.on_field_character,
+                self.off_field_character,
+            )
             logger.info(f"已出售角色：{character.name}")
+            if refunded:
+                logger.info(
+                    f"已回补攻略角色 {character.name} 的购买次数，当前剩余可购买次数：{self.strategy_characters[character.name]}"
+                )
             self.operator.sleep(0.5)
         logger.info("出售操作完成")
 

--- a/tasks/currency_wars/sell_logic.py
+++ b/tasks/currency_wars/sell_logic.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Protocol, Sequence
+
+
+class SellableCharacter(Protocol):
+    name: str
+    priority: int | None
+    is_placed: bool
+
+
+def get_sell_protection_rank(
+    character: SellableCharacter,
+    strategy_characters: dict[str, int],
+) -> int:
+    is_strategy = character.name in strategy_characters
+
+    if not is_strategy and not character.is_placed:
+        return 0
+    if not is_strategy and character.is_placed:
+        return 1
+    if is_strategy and character.is_placed:
+        return 2
+    return 3
+
+
+def build_sell_plan(
+    in_hand_characters: Sequence[SellableCharacter | None],
+    strategy_characters: dict[str, int],
+    force: bool = False,
+    target_hand_count: int = 7,
+) -> list[tuple[int, SellableCharacter]]:
+    current_hand_count = sum(character is not None for character in in_hand_characters)
+    need_to_sell = max(0, current_hand_count - target_hand_count)
+
+    if need_to_sell == 0:
+        return []
+
+    candidates: list[tuple[int, SellableCharacter]] = []
+    for index, character in enumerate(in_hand_characters):
+        if character is None:
+            continue
+        if not force and character.is_placed:
+            continue
+        candidates.append((index, character))
+
+    candidates.sort(
+        key=lambda item: (
+            get_sell_protection_rank(item[1], strategy_characters),
+            item[1].priority if item[1].priority is not None else 999,
+            -item[0],
+        )
+    )
+    return candidates[:need_to_sell]
+
+
+def settle_sold_character(
+    character: SellableCharacter,
+    strategy_characters: dict[str, int],
+    on_field_characters: Sequence[SellableCharacter | None],
+    off_field_characters: Sequence[SellableCharacter | None],
+) -> bool:
+    refunded = False
+    if character.name in strategy_characters:
+        strategy_characters[character.name] += 1
+        refunded = True
+
+    character.is_placed = any(
+        existing is character for existing in [*on_field_characters, *off_field_characters]
+    )
+    return refunded

--- a/test_currency_wars_sell_logic.py
+++ b/test_currency_wars_sell_logic.py
@@ -1,0 +1,91 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+def load_module():
+    module_path = pathlib.Path(__file__).with_name("tasks").joinpath("currency_wars", "sell_logic.py")
+    spec = importlib.util.spec_from_file_location("currency_wars_sell_logic", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sell_logic = load_module()
+
+
+class DummyCharacter:
+    def __init__(self, name: str, priority: int, is_placed: bool):
+        self.name = name
+        self.priority = priority
+        self.is_placed = is_placed
+
+
+class TestSellLogic(unittest.TestCase):
+    def test_force_sell_prefers_placed_non_strategy_over_unplaced_strategy(self):
+        characters = [
+            DummyCharacter("希儿", 99, False),
+            DummyCharacter("黑天鹅", 5, True),
+            DummyCharacter("银狼", 94, True),
+            DummyCharacter("娜塔莎", 95, False),
+            DummyCharacter("佩拉", 93, True),
+            DummyCharacter("花火", 90, True),
+            DummyCharacter("杰帕德", 96, True),
+            DummyCharacter("星期日", 98, True),
+        ]
+
+        result = sell_logic.build_sell_plan(
+            characters,
+            {"希儿": 1, "银狼": 1, "娜塔莎": 1, "佩拉": 1, "花火": 1, "杰帕德": 1, "星期日": 1},
+            force=True,
+            target_hand_count=7,
+        )
+
+        self.assertEqual([item[1].name for item in result], ["黑天鹅"])
+
+    def test_sell_plan_prefers_lower_priority_within_same_protection_group(self):
+        characters = [
+            DummyCharacter("风堇", 2, False),
+            DummyCharacter("翡翠", 1, False),
+            DummyCharacter("椒丘", 3, False),
+            DummyCharacter("忘归人", 4, False),
+            DummyCharacter("缇宝", 2, False),
+            DummyCharacter("大丽花", 1, False),
+            DummyCharacter("貊泽", 1, False),
+            DummyCharacter("那刻夏", 3, False),
+        ]
+
+        result = sell_logic.build_sell_plan(
+            characters,
+            {},
+            target_hand_count=7,
+        )
+
+        self.assertEqual(result[0][1].priority, 1)
+
+    def test_tied_candidates_sell_later_slot_first(self):
+        characters = [
+            DummyCharacter("星期日", 98, False),
+            DummyCharacter("风堇", 1, False),
+            DummyCharacter("娜塔莎", 95, False),
+            DummyCharacter("杰帕德", 96, False),
+            DummyCharacter("佩拉", 93, False),
+            DummyCharacter("花火", 90, False),
+            DummyCharacter("缇宝", 1, False),
+            DummyCharacter("大丽花", 1, False),
+        ]
+
+        result = sell_logic.build_sell_plan(
+            characters,
+            {"星期日": 1, "娜塔莎": 1, "杰帕德": 1, "佩拉": 1, "花火": 1},
+            target_hand_count=7,
+        )
+
+        self.assertEqual(result[0][0], 7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 重排货币战争卖牌保护层级，优先保留未上场的攻略角色，减少对阵容完整度的破坏
- 卖掉攻略角色时回补剩余购买次数，并补充出售前的决策日志，便于定位为什么会卖掉某张牌
- 为卖牌保护等级和同优先级平手时的槽位处理补充独立测试

## Verification
- python -m unittest test_currency_wars_sell_logic.py
- python -m py_compile tasks/currency_wars/CurrencyWars.py tasks/currency_wars/sell_logic.py