### PR TITLE
fix(frontend): 战术加载失败时显示错误toast并跳过无效文件

### DIFF
--- a/SRAFrontend/ViewModels/TaskPageViewModel.cs
+++ b/SRAFrontend/ViewModels/TaskPageViewModel.cs
@@ -122,7 +122,8 @@ public partial class TaskPageViewModel : PageViewModel
         ControlPanelViewModel.StartSingleTask(taskName);
     }
 
-    [RelayCommand]    private void RefreshStrategies()
+    [RelayCommand]
+    private void RefreshStrategies()
     {
         if (!Directory.Exists(PathString.StrategiesDir))
         {
@@ -147,23 +148,6 @@ public partial class TaskPageViewModel : PageViewModel
             {
                 _commonModel.ShowErrorToast("攻略加载失败", $"文件 {Path.GetFileName(file)} 格式错误：{ex.Message}");
             }
-        }
-
-        Cache.Strategies.Clear();
-        Cache.Strategies.AddRange(strategies);
-        CurrencyWarsStrategyIndex = 0;
-    }
-
-        // 遍历攻略文件夹中的json文件，反序列化成Strategy对象，并更新Cache中的Strategies列表
-        var strategies = new List<Strategy>();
-        foreach (var file in Directory.GetFiles(PathString.StrategiesDir))
-        {
-            if (!file.EndsWith(".json")) continue;
-            var json = File.ReadAllText(file);
-            var strategy = JsonSerializer.Deserialize<Strategy>(json);
-            if (strategy is null) continue;
-            strategy.FileName = Path.GetFileNameWithoutExtension(file);
-            strategies.Add(strategy);
         }
 
         Cache.Strategies.Clear();

--- a/SRAFrontend/ViewModels/TaskPageViewModel.cs
+++ b/SRAFrontend/ViewModels/TaskPageViewModel.cs
@@ -122,14 +122,37 @@ public partial class TaskPageViewModel : PageViewModel
         ControlPanelViewModel.StartSingleTask(taskName);
     }
 
-    [RelayCommand]
-    private void RefreshStrategies()
+    [RelayCommand]    private void RefreshStrategies()
     {
         if (!Directory.Exists(PathString.StrategiesDir))
         {
             _commonModel.ShowErrorToast("Error", "未找到攻略文件夹，无法刷新");
             return;
         }
+
+        // 遍历攻略文件夹中的json文件，反序列化成Strategy对象，并更新Cache中的Strategies列表
+        var strategies = new List<Strategy>();
+        foreach (var file in Directory.GetFiles(PathString.StrategiesDir))
+        {
+            if (!file.EndsWith(".json")) continue;
+            var json = File.ReadAllText(file);
+            try
+            {
+                var strategy = JsonSerializer.Deserialize<Strategy>(json);
+                if (strategy is null) continue;
+                strategy.FileName = Path.GetFileNameWithoutExtension(file);
+                strategies.Add(strategy);
+            }
+            catch (JsonException ex)
+            {
+                _commonModel.ShowErrorToast("攻略加载失败", $"文件 {Path.GetFileName(file)} 格式错误：{ex.Message}");
+            }
+        }
+
+        Cache.Strategies.Clear();
+        Cache.Strategies.AddRange(strategies);
+        CurrencyWarsStrategyIndex = 0;
+    }
 
         // 遍历攻略文件夹中的json文件，反序列化成Strategy对象，并更新Cache中的Strategies列表
         var strategies = new List<Strategy>();


### PR DESCRIPTION
修复战术加载失败时程序卡住的问题。现在当攻略文件格式错误时，会显示错误toast提示并跳过该文件，不会导致程序崩溃。