### PR TITLE
Add window position and size persistence

### DIFF
--- a/SRAFrontend/SRAFrontend.Desktop/App.axaml.cs
+++ b/SRAFrontend/SRAFrontend.Desktop/App.axaml.cs
@@ -40,10 +40,8 @@ public class App : Application
             // Avoid duplicate validations from both Avalonia and the CommunityToolkit. 
             // More info: https://docs.avaloniaui.net/docs/guides/development-guides/data-validation#manage-validationplugins
             DisableAvaloniaDataAnnotationValidation();
-            desktop.MainWindow = new MainWindow
-            {
-                DataContext = serviceProvider.GetRequiredService<MainWindowViewModel>(),
-            };
+            desktop.MainWindow = serviceProvider.GetRequiredService<MainWindow>();
+            desktop.MainWindow.DataContext = serviceProvider.GetRequiredService<MainWindowViewModel>();
             desktop.MainWindow.Closed += (_, _) => serviceProvider.GetRequiredService<OverlayService>().CloseOverlay();
             desktop.Exit += (_, _) =>
             {
@@ -69,6 +67,7 @@ public class App : Application
             loggingBuilder.AddSerilog(dispose: true);
         });
         // Register your services here
+        services.AddTransient<MainWindow>();
         services.AddTransient<MainWindowViewModel>();
         services.AddTransient<PageViewModel, HomePageViewModel>();
         services.AddTransient<PageViewModel, TaskPageViewModel>();

--- a/SRAFrontend/SRAFrontend.Desktop/Views/MainWindow.axaml.cs
+++ b/SRAFrontend/SRAFrontend.Desktop/Views/MainWindow.axaml.cs
@@ -1,19 +1,48 @@
+using Avalonia;
+using System;
 using Avalonia.Interactivity;
 using SRAFrontend.Desktop.ViewModels;
+using SRAFrontend.Services;
 using SukiUI.Controls;
 
 namespace SRAFrontend.Desktop.Views;
 
 public partial class MainWindow : SukiWindow
 {
-    public MainWindow()
+    private readonly SettingsService _settingsService;
+
+    public MainWindow(SettingsService settingsService)
     {
+        _settingsService = settingsService;
         InitializeComponent();
+        Closed += OnClosed;
     }
 
     protected override void OnLoaded(RoutedEventArgs e)
     {
         base.OnLoaded(e);
+        var displaySettings = _settingsService.Settings.Display;
+        if (displaySettings.WindowWidth > 0 && displaySettings.WindowHeight > 0)
+        {
+            Width = displaySettings.WindowWidth;
+            Height = displaySettings.WindowHeight;
+        }
+
+        if (displaySettings.WindowPositionX != 0 || displaySettings.WindowPositionY != 0)
+        {
+            Position = new PixelPoint((int)displaySettings.WindowPositionX, (int)displaySettings.WindowPositionY);
+        }
+
         (DataContext as MainWindowViewModel)?.InitializeAsync();
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        var displaySettings = _settingsService.Settings.Display;
+        displaySettings.WindowPositionX = Position.X;
+        displaySettings.WindowPositionY = Position.Y;
+        displaySettings.WindowWidth = Width;
+        displaySettings.WindowHeight = Height;
+        _settingsService.Save();
     }
 }

--- a/SRAFrontend/SRAFrontend.Desktop/Views/MainWindow.axaml.cs
+++ b/SRAFrontend/SRAFrontend.Desktop/Views/MainWindow.axaml.cs
@@ -22,15 +22,18 @@ public partial class MainWindow : SukiWindow
     {
         base.OnLoaded(e);
         var displaySettings = _settingsService.Settings.Display;
-        if (displaySettings.WindowWidth > 0 && displaySettings.WindowHeight > 0)
+        if (displaySettings.IsRememberWindowSizeAndPosition)
         {
-            Width = displaySettings.WindowWidth;
-            Height = displaySettings.WindowHeight;
-        }
+            if (displaySettings.WindowWidth > 0 && displaySettings.WindowHeight > 0)
+            {
+                Width = displaySettings.WindowWidth;
+                Height = displaySettings.WindowHeight;
+            }
 
-        if (displaySettings.WindowPositionX != 0 || displaySettings.WindowPositionY != 0)
-        {
-            Position = new PixelPoint((int)displaySettings.WindowPositionX, (int)displaySettings.WindowPositionY);
+            if (displaySettings.WindowPositionX != 0 || displaySettings.WindowPositionY != 0)
+            {
+                Position = new PixelPoint((int)displaySettings.WindowPositionX, (int)displaySettings.WindowPositionY);
+            }
         }
 
         (DataContext as MainWindowViewModel)?.InitializeAsync();
@@ -39,10 +42,13 @@ public partial class MainWindow : SukiWindow
     private void OnClosed(object? sender, EventArgs e)
     {
         var displaySettings = _settingsService.Settings.Display;
-        displaySettings.WindowPositionX = Position.X;
-        displaySettings.WindowPositionY = Position.Y;
-        displaySettings.WindowWidth = Width;
-        displaySettings.WindowHeight = Height;
-        _settingsService.Save();
+        if (displaySettings.IsRememberWindowSizeAndPosition)
+        {
+            displaySettings.WindowPositionX = Position.X;
+            displaySettings.WindowPositionY = Position.Y;
+            displaySettings.WindowWidth = Width;
+            displaySettings.WindowHeight = Height;
+            _settingsService.Save();
+        }
     }
 }

--- a/SRAFrontend/SRAFrontend.Desktop/Views/MainWindow.axaml.cs
+++ b/SRAFrontend/SRAFrontend.Desktop/Views/MainWindow.axaml.cs
@@ -22,7 +22,7 @@ public partial class MainWindow : SukiWindow
     {
         base.OnLoaded(e);
         var displaySettings = _settingsService.Settings.Display;
-        if (displaySettings.IsRememberWindowSizeAndPosition)
+        if (displaySettings.IsRememberWindow)
         {
             if (displaySettings.WindowWidth > 0 && displaySettings.WindowHeight > 0)
             {
@@ -42,7 +42,7 @@ public partial class MainWindow : SukiWindow
     private void OnClosed(object? sender, EventArgs e)
     {
         var displaySettings = _settingsService.Settings.Display;
-        if (displaySettings.IsRememberWindowSizeAndPosition)
+        if (displaySettings.IsRememberWindow)
         {
             displaySettings.WindowPositionX = Position.X;
             displaySettings.WindowPositionY = Position.Y;

--- a/SRAFrontend/SRAFrontend.Desktop/Views/SettingsPageView.axaml
+++ b/SRAFrontend/SRAFrontend.Desktop/Views/SettingsPageView.axaml
@@ -231,7 +231,7 @@
                                         <Label Grid.Column="0" Classes="Icon">&#xE5CA;</Label>
                                         <Label Grid.Column="1" Content="记忆窗口大小和位置" />
                                         <ToggleSwitch Grid.Column="2"
-                                                      IsChecked="{Binding DisplaySettings.IsRememberWindowSizeAndPosition}"
+                                                      IsChecked="{Binding DisplaySettings.IsRememberWindow}"
                                                       ToolTip.Tip="启用后，SRA会记住窗口的位置和大小，下次启动时恢复" />
                                     </Grid>
                                 </StackPanel>

--- a/SRAFrontend/SRAFrontend.Desktop/Views/SettingsPageView.axaml
+++ b/SRAFrontend/SRAFrontend.Desktop/Views/SettingsPageView.axaml
@@ -227,6 +227,13 @@
                                             <ComboBoxItem>English</ComboBoxItem>
                                         </ComboBox>
                                     </Grid>
+                                    <Grid ColumnDefinitions="Auto, *, Auto">
+                                        <Label Grid.Column="0" Classes="Icon">&#xE5CA;</Label>
+                                        <Label Grid.Column="1" Content="记忆窗口大小和位置" />
+                                        <ToggleSwitch Grid.Column="2"
+                                                      IsChecked="{Binding DisplaySettings.IsRememberWindowSizeAndPosition}"
+                                                      ToolTip.Tip="启用后，SRA会记住窗口的位置和大小，下次启动时恢复" />
+                                    </Grid>
                                 </StackPanel>
                             </suki:SettingsLayoutItem.Content>
                         </suki:SettingsLayoutItem>

--- a/SRAFrontend/SRAFrontend/Models/AppSettings.cs
+++ b/SRAFrontend/SRAFrontend/Models/AppSettings.cs
@@ -142,8 +142,8 @@ public partial class DisplaySettings : ObservableObject
     private double _windowHeight;
 
     [ObservableProperty]
-    [property: JsonPropertyName("window.rememberSizeAndPosition")]
-    private bool _isRememberWindowSizeAndPosition = true;
+    [property: JsonPropertyName("window.remember")]
+    private bool _isRememberWindow = true;
 }
 
 public partial class NotificationSettings : ObservableObject

--- a/SRAFrontend/SRAFrontend/Models/AppSettings.cs
+++ b/SRAFrontend/SRAFrontend/Models/AppSettings.cs
@@ -124,6 +124,22 @@ public partial class DisplaySettings : ObservableObject
     [ObservableProperty]
     [property: JsonPropertyName("language")]
     private int _language;
+
+    [ObservableProperty]
+    [property: JsonPropertyName("window.position.x")]
+    private double _windowPositionX;
+
+    [ObservableProperty]
+    [property: JsonPropertyName("window.position.y")]
+    private double _windowPositionY;
+
+    [ObservableProperty]
+    [property: JsonPropertyName("window.width")]
+    private double _windowWidth;
+
+    [ObservableProperty]
+    [property: JsonPropertyName("window.height")]
+    private double _windowHeight;
 }
 
 public partial class NotificationSettings : ObservableObject

--- a/SRAFrontend/SRAFrontend/Models/AppSettings.cs
+++ b/SRAFrontend/SRAFrontend/Models/AppSettings.cs
@@ -140,6 +140,10 @@ public partial class DisplaySettings : ObservableObject
     [ObservableProperty]
     [property: JsonPropertyName("window.height")]
     private double _windowHeight;
+
+    [ObservableProperty]
+    [property: JsonPropertyName("window.rememberSizeAndPosition")]
+    private bool _isRememberWindowSizeAndPosition = true;
 }
 
 public partial class NotificationSettings : ObservableObject


### PR DESCRIPTION
这个PR实现了issue #199，添加了窗口位置和大小的持久化功能。应用程序现在会记住上一次会话的窗口位置和大小，并在启动时恢复它们。

更改内容：
- 在DisplaySettings中添加了WindowPositionX、WindowPositionY、WindowWidth、WindowHeight属性
- 修改了MainWindow以保存和恢复窗口几何信息
- 在依赖注入容器中注册了MainWindow

Close #199