### PR TITLE
fix(frontend): correct trigger set command parameter order

### DIFF
--- a/SRAFrontend/SRAFrontend.Desktop/ViewModels/ExtensionPageViewModel.cs
+++ b/SRAFrontend/SRAFrontend.Desktop/ViewModels/ExtensionPageViewModel.cs
@@ -27,7 +27,7 @@ public class ExtensionPageViewModel(IBackendService backendService) : PageViewMo
         {
             _skipPlot = value;
             OnPropertyChanged();
-            _ = backendService.SendInputAsync($"trigger set --type AutoPlotTrigger skip_plot {value}");
+            _ = backendService.SendInputAsync($"trigger set AutoPlotTrigger skip_plot --type bool {value}");
         }
     }
 }


### PR DESCRIPTION
Fix the parameter order in ExtensionPageViewModel SkipPlot setter.

Before: `trigger set --type AutoPlotTrigger skip_plot {value}`
After: `trigger set AutoPlotTrigger skip_plot --type bool {value}`

The --type flag was incorrectly placed before the trigger name, causing the error: `invalid choice: 'AutoPlotTrigger'`