### PR TITLE
fix: 修复 README 中失效的 Star 历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ nothing to do with it.
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Shasnow/StarRailAssistant&type=Date)](https://star-history.com/#Shasnow/StarRailAssistant&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Shasnow/StarRailAssistant&type=Date)](https://star-history.dera.page/#Shasnow/StarRailAssistant&Date)
 
 ----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
当前 README 中的 Star 历史图表已失效，无法正常加载，影响了项目展示。本 PR 将图表链接更新至可正常访问的地址，恢复图表功能。

修复后 Star 历史图表将正常展示项目的 Star 增长情况。