### PR TITLE
feat: 支持国际服自动登录前选择区服

### DIFF
--- a/SRACore/models/tasks_config.py
+++ b/SRACore/models/tasks_config.py
@@ -50,6 +50,7 @@ class StartGameConfig:
 
     isEnabled: bool = True
     gameChannel: int = 0
+    gameServer: int = 0
     gamePath: str = ""
     isUseGlobalGamePath: bool = True
     isAutoLogin: bool = True
@@ -62,6 +63,7 @@ class StartGameConfig:
         return {
             "enabled": self.isEnabled,
             "game.channel": self.gameChannel,
+            "game.server": self.gameServer,
             "game.path": self.gamePath,
             "game.useGlobalPath": self.isUseGlobalGamePath,
             "autologin": self.isAutoLogin,
@@ -76,6 +78,7 @@ class StartGameConfig:
         return cls(**{
             "isEnabled": data.get("enabled", True),
             "gameChannel": data.get("game.channel", 0),
+            "gameServer": data.get("game.server", 0),
             "gamePath": data.get("game.path", ""),
             "isUseGlobalGamePath": data.get("game.useGlobalPath", True),
             "isAutoLogin": data.get("autologin", True),

--- a/SRACore/util/const.py
+++ b/SRACore/util/const.py
@@ -17,7 +17,7 @@ import sys
 from pathlib import Path
 
 # 基础的常量定义
-VERSION = "2.20.0-beta.1"  # 版本号
+VERSION = "2.20.0-beta.2"  # 版本号
 CORE = f"{VERSION} on {sys.platform}"  # 核心版本信息
 
 AppRootDir = Path(__file__).parent.parent.parent.absolute()

--- a/SRAFrontend/SRAFrontend.Desktop/Controls/Converters.cs
+++ b/SRAFrontend/SRAFrontend.Desktop/Controls/Converters.cs
@@ -21,6 +21,21 @@ public class ZeroToBooleanConverter : IValueConverter
     }
 }
 
+public class GlobalChannelConverter : IValueConverter
+{
+    public static readonly GlobalChannelConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is int channel && channel == 2;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}
+
 public class DateToStringConverter : IValueConverter
 {
     public static readonly DateToStringConverter Instance = new();

--- a/SRAFrontend/SRAFrontend.Desktop/Views/TaskViews/StartGameView.axaml
+++ b/SRAFrontend/SRAFrontend.Desktop/Views/TaskViews/StartGameView.axaml
@@ -29,7 +29,6 @@
                             <ComboBoxItem>国际服</ComboBoxItem>
                         </ComboBox>
                     </Grid>
-                    
                     <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto" ColumnSpacing="12">
                         <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="12">
                             <Label Content="{x:Static lang:Resources.GamePathText}"/>
@@ -62,6 +61,15 @@
                         <!-- ReSharper disable once Xaml.StyleClassNotFound -->
                         <TextBox Grid.Row="1" Grid.Column="1" Classes="revealPasswordButton" PasswordChar="*"
                                  Text="{Binding StartGameConfig.Password}"/> 
+                    </Grid>
+                    <Grid Margin="0,15,0,0" ColumnDefinitions="Auto, Auto">
+                        <TextBlock Text="国际服区服" VerticalAlignment="Center" />
+                        <ComboBox Grid.Column="1" SelectedIndex="{Binding StartGameConfig.GameServer}">
+                            <ComboBoxItem>Asia</ComboBoxItem>
+                            <ComboBoxItem>Europe</ComboBoxItem>
+                            <ComboBoxItem>America</ComboBoxItem>
+                            <ComboBoxItem>TW,HK,MO</ComboBoxItem>
+                        </ComboBox>
                     </Grid>
                 </StackPanel>
             </ScrollViewer>

--- a/SRAFrontend/SRAFrontend.Desktop/Views/TaskViews/StartGameView.axaml
+++ b/SRAFrontend/SRAFrontend.Desktop/Views/TaskViews/StartGameView.axaml
@@ -21,8 +21,15 @@
             </suki:GroupBox.Header>
             <ScrollViewer>
                 <StackPanel Margin="10">
-                    <Grid Margin="0,0,0,15" ColumnDefinitions="Auto, Auto">
+                    <Grid Margin="0,0,0,15" ColumnDefinitions="Auto, Auto, Auto, Auto" ColumnSpacing="12">
                         <TextBlock Text="渠道" VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="2" Text="国际服区服" VerticalAlignment="Center" />
+                        <ComboBox Grid.Column="3" SelectedIndex="{Binding StartGameConfig.GameServer}">
+                            <ComboBoxItem>Asia</ComboBoxItem>
+                            <ComboBoxItem>Europe</ComboBoxItem>
+                            <ComboBoxItem>America</ComboBoxItem>
+                            <ComboBoxItem>TW,HK,MO</ComboBoxItem>
+                        </ComboBox>
                         <ComboBox Grid.Column="1" SelectedIndex="{Binding StartGameConfig.GameChannel}">
                             <ComboBoxItem>官服</ComboBoxItem>
                             <ComboBoxItem>b服</ComboBoxItem>
@@ -61,15 +68,6 @@
                         <!-- ReSharper disable once Xaml.StyleClassNotFound -->
                         <TextBox Grid.Row="1" Grid.Column="1" Classes="revealPasswordButton" PasswordChar="*"
                                  Text="{Binding StartGameConfig.Password}"/> 
-                    </Grid>
-                    <Grid Margin="0,15,0,0" ColumnDefinitions="Auto, Auto">
-                        <TextBlock Text="国际服区服" VerticalAlignment="Center" />
-                        <ComboBox Grid.Column="1" SelectedIndex="{Binding StartGameConfig.GameServer}">
-                            <ComboBoxItem>Asia</ComboBoxItem>
-                            <ComboBoxItem>Europe</ComboBoxItem>
-                            <ComboBoxItem>America</ComboBoxItem>
-                            <ComboBoxItem>TW,HK,MO</ComboBoxItem>
-                        </ComboBox>
                     </Grid>
                 </StackPanel>
             </ScrollViewer>

--- a/SRAFrontend/SRAFrontend.Desktop/Views/TaskViews/StartGameView.axaml
+++ b/SRAFrontend/SRAFrontend.Desktop/Views/TaskViews/StartGameView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:suki="https://github.com/kikipoulet/SukiUI"
+             xmlns:controls="clr-namespace:SRAFrontend.Desktop.Controls"
              xmlns:lang="clr-namespace:SRAFrontend.Localization;assembly=SRAFrontend"
              xmlns:viewModels="clr-namespace:SRAFrontend.Desktop.ViewModels"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
@@ -23,18 +24,21 @@
                 <StackPanel Margin="10">
                     <Grid Margin="0,0,0,15" ColumnDefinitions="Auto, Auto, Auto, Auto" ColumnSpacing="12">
                         <TextBlock Text="渠道" VerticalAlignment="Center" />
-                        <TextBlock Grid.Column="2" Text="国际服区服" VerticalAlignment="Center" />
-                        <ComboBox Grid.Column="3" SelectedIndex="{Binding StartGameConfig.GameServer}">
-                            <ComboBoxItem>Asia</ComboBoxItem>
-                            <ComboBoxItem>Europe</ComboBoxItem>
-                            <ComboBoxItem>America</ComboBoxItem>
-                            <ComboBoxItem>TW,HK,MO</ComboBoxItem>
-                        </ComboBox>
                         <ComboBox Grid.Column="1" SelectedIndex="{Binding StartGameConfig.GameChannel}">
                             <ComboBoxItem>官服</ComboBoxItem>
                             <ComboBoxItem>b服</ComboBoxItem>
                             <ComboBoxItem>国际服</ComboBoxItem>
                         </ComboBox>
+                        <StackPanel Grid.Column="2" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="12"
+                                    IsVisible="{Binding StartGameConfig.GameChannel, Converter={x:Static controls:GlobalChannelConverter.Instance}}">
+                            <TextBlock Text="国际服区服" VerticalAlignment="Center" />
+                            <ComboBox SelectedIndex="{Binding StartGameConfig.GameServer}">
+                                <ComboBoxItem>Asia</ComboBoxItem>
+                                <ComboBoxItem>Europe</ComboBoxItem>
+                                <ComboBoxItem>America</ComboBoxItem>
+                                <ComboBoxItem>TW,HK,MO</ComboBoxItem>
+                            </ComboBox>
+                        </StackPanel>
                     </Grid>
                     <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto" ColumnSpacing="12">
                         <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="12">

--- a/SRAFrontend/SRAFrontend/Models/AppSettings.cs
+++ b/SRAFrontend/SRAFrontend/Models/AppSettings.cs
@@ -7,7 +7,7 @@ namespace SRAFrontend.Models;
 
 public class AppSettings
 {
-    public const string Version = "2.20.0-beta.1"; // 应用版本号
+    public const string Version = "2.20.0-beta.2"; // 应用版本号
 
     [JsonPropertyName("general")] public GeneralSettings General { get; init; } = new();
 

--- a/SRAFrontend/SRAFrontend/Models/TasksConfig.cs
+++ b/SRAFrontend/SRAFrontend/Models/TasksConfig.cs
@@ -28,6 +28,9 @@ public partial class StartGameConfig : ObservableObject
     [ObservableProperty] [property: JsonPropertyName("game.channel")]
     private int _gameChannel;
 
+    [ObservableProperty] [property: JsonPropertyName("game.server")]
+    private int _gameServer;
+
     [ObservableProperty] [property: JsonPropertyName("game.path")]
     private string _gamePath = "";
 

--- a/SRAFrontend/srafrontend-webui/src/components/TaskEditor.vue
+++ b/SRAFrontend/srafrontend-webui/src/components/TaskEditor.vue
@@ -39,6 +39,15 @@
               <span>密码</span>
               <el-input v-model="localStartPassword" type="password" show-password placeholder="留空则保留已保存密码" />
             </label>
+            <label class="field">
+              <span>国际服区服</span>
+              <el-select v-model="configModel.startGame['game.server']" :disabled="configModel.startGame['game.channel'] !== 2">
+                <el-option label="Asia" :value="0" />
+                <el-option label="Europe" :value="1" />
+                <el-option label="America" :value="2" />
+                <el-option label="TW,HK,MO" :value="3" />
+              </el-select>
+            </label>
           </div>
         </section>
       </el-tab-pane>

--- a/SRAFrontend/srafrontend-webui/src/components/TaskEditor.vue
+++ b/SRAFrontend/srafrontend-webui/src/components/TaskEditor.vue
@@ -24,9 +24,9 @@
                 <el-option label="国际服" :value="2" />
               </el-select>
             </label>
-            <label class="field">
+            <label v-if="configModel.startGame['game.channel'] === 2" class="field">
               <span>国际服区服</span>
-              <el-select v-model="configModel.startGame['game.server']" :disabled="configModel.startGame['game.channel'] !== 2">
+              <el-select v-model="configModel.startGame['game.server']">
                 <el-option label="Asia" :value="0" />
                 <el-option label="Europe" :value="1" />
                 <el-option label="America" :value="2" />

--- a/SRAFrontend/srafrontend-webui/src/components/TaskEditor.vue
+++ b/SRAFrontend/srafrontend-webui/src/components/TaskEditor.vue
@@ -24,6 +24,15 @@
                 <el-option label="国际服" :value="2" />
               </el-select>
             </label>
+            <label class="field">
+              <span>国际服区服</span>
+              <el-select v-model="configModel.startGame['game.server']" :disabled="configModel.startGame['game.channel'] !== 2">
+                <el-option label="Asia" :value="0" />
+                <el-option label="Europe" :value="1" />
+                <el-option label="America" :value="2" />
+                <el-option label="TW,HK,MO" :value="3" />
+              </el-select>
+            </label>
             <label class="field wide">
               <span>游戏路径</span>
               <el-input v-model="configModel.startGame['game.path']" :disabled="configModel.startGame['game.useGlobalPath']" placeholder="使用全局路径时会忽略此项" />
@@ -38,15 +47,6 @@
             <label class="field">
               <span>密码</span>
               <el-input v-model="localStartPassword" type="password" show-password placeholder="留空则保留已保存密码" />
-            </label>
-            <label class="field">
-              <span>国际服区服</span>
-              <el-select v-model="configModel.startGame['game.server']" :disabled="configModel.startGame['game.channel'] !== 2">
-                <el-option label="Asia" :value="0" />
-                <el-option label="Europe" :value="1" />
-                <el-option label="America" :value="2" />
-                <el-option label="TW,HK,MO" :value="3" />
-              </el-select>
             </label>
           </div>
         </section>

--- a/SRAFrontend/srafrontend-webui/src/models/taskConfig.ts
+++ b/SRAFrontend/srafrontend-webui/src/models/taskConfig.ts
@@ -13,6 +13,7 @@ export function createConfigModel(source: unknown, fallbackName: string): TaskCo
     startGame: {
       enabled: true,
       'game.channel': 0,
+      'game.server': 0,
       'game.path': '',
       'game.useGlobalPath': true,
       autologin: true,

--- a/SRAFrontend/srafrontend-webui/src/types/task.ts
+++ b/SRAFrontend/srafrontend-webui/src/types/task.ts
@@ -35,6 +35,7 @@ export type TaskConfig = {
   startGame: {
     enabled: boolean
     'game.channel': number
+    'game.server': number
     'game.path': string
     'game.useGlobalPath': boolean
     autologin: boolean

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sra",
-  "version": "2.20.0-beta.1",
+  "version": "2.20.0-beta.2",
   "scripts": {
     "dev": "python main.py",
     "build": "dotnet publish -c Release -r win-x64 SRAFrontend/SRAFrontend.sln && python scripts/package.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "starrailassistant"
-version = "2.20.0-beta.1"
+version = "2.20.0-beta.2"
 description = "崩坏：星穹铁道自动化助手"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/tasks/StartGameTask.py
+++ b/tasks/StartGameTask.py
@@ -165,9 +165,16 @@ class StartGameTask(BaseTask):
         labels = ["Asia", "Europe", "America", "TW,HK,MO"]
         server_index = max(0, min(int(getattr(self.config.StartGame, "gameServer", 0)), len(labels) - 1))
         target = labels[server_index]
-        # OCR boxes from a cropped screenshot are crop-relative. Keep these
-        # lookups full-screen because their boxes are clicked directly below.
-        index, box = self.operator.wait_ocr_any(labels, timeout=15)
+        # All four bounds are required for cropped OCR so the returned box is
+        # offset back into window coordinates correctly before click_box().
+        index, box = self.operator.wait_ocr_any(
+            labels,
+            timeout=15,
+            from_x=0,
+            from_y=0.55,
+            to_x=1,
+            to_y=0.95,
+        )
         if index < 0 or box is None:
             logger.warning("未检测到国际服区服选择器，跳过区服切换")
             return False

--- a/tasks/StartGameTask.py
+++ b/tasks/StartGameTask.py
@@ -125,8 +125,6 @@ class StartGameTask(BaseTask):
             else:
                 return result  # 直接返回登录状态
 
-        if channel == 'gb':
-            self.select_global_server()
         self.operator.click_img(SGIMG.LOGIN_OTHER % channel, after_sleep=1)
         # The global client exposes the account fields directly on this page.
         if channel != 'gb':
@@ -200,6 +198,8 @@ class StartGameTask(BaseTask):
         return False
 
     def start_game_click(self):
+        if self.config.StartGame.gameChannel == 2:
+            self.select_global_server()
         result, _ = self.operator.wait_ocr_any(["开始游戏", "点击进入"], interval=1, timeout=60, from_x=0.44,
                                                from_y=0.74, to_x=0.57, to_y=0.97)
         if result == 0:

--- a/tasks/StartGameTask.py
+++ b/tasks/StartGameTask.py
@@ -165,17 +165,24 @@ class StartGameTask(BaseTask):
         labels = ["Asia", "Europe", "America", "TW,HK,MO"]
         server_index = max(0, min(int(getattr(self.config.StartGame, "gameServer", 0)), len(labels) - 1))
         target = labels[server_index]
-        index, box = self.operator.wait_ocr_any(labels, timeout=15, from_y=0.65, to_y=0.98)
+        # OCR boxes from a cropped screenshot are crop-relative. Keep these
+        # lookups full-screen because their boxes are clicked directly below.
+        index, box = self.operator.wait_ocr_any(labels, timeout=15)
         if index < 0 or box is None:
             logger.warning("未检测到国际服区服选择器，跳过区服切换")
             return False
+        logger.info(f"打开国际服区服选择器，当前区服: {labels[index]}，目标区服: {target}")
         self.operator.click_box(box, after_sleep=1)
-        index, box = self.operator.wait_ocr_any([target], timeout=10, from_y=0.25, to_y=0.75)
+        index, _ = self.operator.wait_ocr_any(["服务器列表", "Server List"], timeout=10)
+        if index < 0:
+            logger.warning("未检测到国际服区服选择弹窗")
+            return False
+        index, box = self.operator.wait_ocr_any([target], timeout=10)
         if index < 0 or box is None:
             logger.warning(f"未检测到国际服目标区服: {target}")
             return False
         self.operator.click_box(box, after_sleep=0.5)
-        index, box = self.operator.wait_ocr_any(["确认", "Confirm"], timeout=5, from_y=0.55, to_y=0.95)
+        index, box = self.operator.wait_ocr_any(["确认", "Confirm"], timeout=5)
         if index >= 0 and box is not None:
             self.operator.click_box(box, after_sleep=1)
             logger.info(f"已选择国际服区服: {target}")

--- a/tasks/StartGameTask.py
+++ b/tasks/StartGameTask.py
@@ -125,8 +125,12 @@ class StartGameTask(BaseTask):
             else:
                 return result  # 直接返回登录状态
 
+        if channel == 'gb':
+            self.select_global_server()
         self.operator.click_img(SGIMG.LOGIN_OTHER % channel, after_sleep=1)
-        self.operator.click_img(SGIMG.LOGIN_WITH_ACCOUNT % channel, after_sleep=1)
+        # The global client exposes the account fields directly on this page.
+        if channel != 'gb':
+            self.operator.click_img(SGIMG.LOGIN_WITH_ACCOUNT % channel, after_sleep=1)
         if self.config.StartGame.isAutoLogin:
             user = encryption.decryptor(self.config.StartGame.EncryptedUsername)
             passwd = encryption.decryptor(self.config.StartGame.EncryptedPassword)
@@ -142,7 +146,12 @@ class StartGameTask(BaseTask):
             self.operator.sleep(0.2)
             self.operator.copy(passwd)
             self.operator.paste()
-            self.operator.click_img(SGIMG.AGREE % channel, x_offset=-35, after_sleep=1)
+            if channel == 'gb':
+                index, box = self.operator.wait_ocr_any(["同意", "Agree"], timeout=10, from_y=0.55, to_y=0.95)
+                if index >= 0 and box is not None:
+                    self.operator.click_box(box, x_offset=-35, after_sleep=1)
+            else:
+                self.operator.click_img(SGIMG.AGREE % channel, x_offset=-35, after_sleep=1)
             self.operator.click_img(SGIMG.ENTER_GAME % channel)
         else:
             logger.info("未启用自动登录，请手动完成登录")
@@ -152,6 +161,29 @@ class StartGameTask(BaseTask):
         else:
             logger.warning("登录后等待欢迎界面超时，请检查游戏状态")
             return -1
+
+    def select_global_server(self):
+        """Select and confirm the configured global server before login."""
+        labels = ["Asia", "Europe", "America", "TW,HK,MO"]
+        server_index = max(0, min(int(getattr(self.config.StartGame, "gameServer", 0)), len(labels) - 1))
+        target = labels[server_index]
+        index, box = self.operator.wait_ocr_any(labels, timeout=15, from_y=0.65, to_y=0.98)
+        if index < 0 or box is None:
+            logger.warning("未检测到国际服区服选择器，跳过区服切换")
+            return False
+        self.operator.click_box(box, after_sleep=1)
+        index, box = self.operator.wait_ocr_any([target], timeout=10, from_y=0.25, to_y=0.75)
+        if index < 0 or box is None:
+            logger.warning(f"未检测到国际服目标区服: {target}")
+            return False
+        self.operator.click_box(box, after_sleep=0.5)
+        index, box = self.operator.wait_ocr_any(["确认", "Confirm"], timeout=5, from_y=0.55, to_y=0.95)
+        if index >= 0 and box is not None:
+            self.operator.click_box(box, after_sleep=1)
+            logger.info(f"已选择国际服区服: {target}")
+            return True
+        logger.warning(f"国际服区服选择未找到确认按钮: {target}")
+        return False
 
     def logout(self):
         logger.info("登出账号")

--- a/tasks/taskcli.py
+++ b/tasks/taskcli.py
@@ -4,10 +4,11 @@ import tomllib
 
 import cmd2
 
+from SRACore.cli2 import SRACli
 from SRACore.util.const import AppRootDir
 
 
-class TrailblazePowerCommands(cmd2.CommandSet):
+class TrailblazePowerCommands(cmd2.CommandSet[SRACli]):
     DEFAULT_CATEGORY = 'Trailblaze Power'
 
     @staticmethod
@@ -54,7 +55,7 @@ class TrailblazePowerCommands(cmd2.CommandSet):
             self._cmd.poutput("")
 
 
-class CurrencyWarsCommands(cmd2.CommandSet):
+class CurrencyWarsCommands(cmd2.CommandSet[SRACli]):
     DEFAULT_CATEGORY = 'Currency Wars'
 
     @staticmethod

--- a/tasks/taskcli.py
+++ b/tasks/taskcli.py
@@ -4,11 +4,10 @@ import tomllib
 
 import cmd2
 
-from SRACore.cli2 import SRACli
 from SRACore.util.const import AppRootDir
 
 
-class TrailblazePowerCommands(cmd2.CommandSet[SRACli]):
+class TrailblazePowerCommands(cmd2.CommandSet):
     DEFAULT_CATEGORY = 'Trailblaze Power'
 
     @staticmethod
@@ -55,7 +54,7 @@ class TrailblazePowerCommands(cmd2.CommandSet[SRACli]):
             self._cmd.poutput("")
 
 
-class CurrencyWarsCommands(cmd2.CommandSet[SRACli]):
+class CurrencyWarsCommands(cmd2.CommandSet):
     DEFAULT_CATEGORY = 'Currency Wars'
 
     @staticmethod


### PR DESCRIPTION
## 变更内容
- 为国际服增加可配置的区服选择：Asia、Europe、America、TW,HK,MO。
- 在开始游戏页点击当前区服，打开服务器列表后选择目标区服并确认。
- 桌面端与 WebUI 仅在选择国际服时显示区服下拉框。
- 修复部分 `cmd2` 版本中 `CommandSet` 不支持泛型而导致打包程序无法启动的问题。

## 验证
- `python -m compileall -q tasks SRACore`
- 桌面端与服务端 .NET 构建通过。
- WebUI Vite 构建通过。
- 已完成本地完整打包和部署测试。

关联 #211