### PR TITLE
修复Operator对象缺少width属性的问题

### DIFF
--- a/SRACore/task/__init__.py
+++ b/SRACore/task/__init__.py
@@ -56,9 +56,9 @@ class BaseTask(Executable, ABC):
             self.send_notification(f"任务 {self.__class__.__name__} 执行完成。", "success")
 
     def on_failed(self) -> None:
-        if self.operator.width != 1920 or self.operator.height != 1080:
+        if self.operator.window_context.width != 1920 or self.operator.window_context.height != 1080:
             logger.warning(
-                f"可能的失败原因：游戏分辨率不符合要求：1920x1080，当前：{self.operator.width}x{self.operator.height}。")
+                f"可能的失败原因：游戏分辨率不符合要求：1920x1080，当前：{self.operator.window_context.width}x{self.operator.window_context.height}。")
         image = None
         try:
             image = self.operator.screenshot()

--- a/extensions/warp_forecast.py
+++ b/extensions/warp_forecast.py
@@ -520,7 +520,7 @@ class WarpForecastExtension(BaseExtension[WarpForecastConfig]):
         for item in _ocr_items(results, 0.55):
             if text in str(item[1]):
                 x, y = _box_center(item)
-                if self.operator.width and self.operator.height:
+                if self.operator.window_context.width and self.operator.window_context.height:
                     self.operator.click_point(int(x), int(y), after_sleep=0.5)
                 else:
                     self.operator.click_point(fallback[0], fallback[1], after_sleep=0.5)

--- a/tasks/TrailblazePowerTask.py
+++ b/tasks/TrailblazePowerTask.py
@@ -666,7 +666,7 @@ class TrailblazePowerTask(BaseTask):
         x1, y1, x2, y2 = 45, 190, 155, 320
 
         # 检查第一个支援角色是否有替换图标（与队伍中角色重复）
-        w, h = self.operator.width, self.operator.height
+        w, h = self.operator.window_context.width, self.operator.window_context.height
         has_replace = self.operator.locate(
             TPIMG.DUPLICATE_REPLACED,
             from_x=x1 / w, from_y=y1 / h,

--- a/tasks/currency_wars/CurrencyWars.py
+++ b/tasks/currency_wars/CurrencyWars.py
@@ -502,7 +502,7 @@ class CurrencyWars(Executable):
         if boxes:
             sorted_boxes = sorted(boxes, key=lambda b: b.left)
             self.off_field_area = [
-                (b.center[0] / self.operator.width, b.center[1] / self.operator.height)
+                (b.center[0] / self.operator.window_context.width, b.center[1] / self.operator.window_context.height)
                 for b in sorted_boxes
             ]
             # 同步调整角色列表长度


### PR DESCRIPTION
修复了SRA中Operator对象缺少width属性导致的AttributeError错误。将所有改为，涉及文件：
- tasks/TrailblazePowerTask.py
- extensions/warp_forecast.py
- tasks/currency_wars/CurrencyWars.py
- SRACore/task/__init__.py